### PR TITLE
Migrate to chodeus-ops (phase 1)

### DIFF
--- a/.github/workflows/repo-events.yml
+++ b/.github/workflows/repo-events.yml
@@ -1,0 +1,20 @@
+# Drop into .github/workflows/repo-events.yml of ANY repo.
+# Fires Discord for: issue open/close, PR open/close/merge, release publish, discussion.
+# Workflow-failure notifications are handled inline by the failing caller workflow (see caller-docker.yml).
+
+name: Repo events
+
+on:
+  issues:
+    types: [opened, closed, reopened]
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review]
+  release:
+    types: [published]
+  discussion:
+    types: [created]
+
+jobs:
+  notify:
+    uses: chodeus/chodeus-ops/workflows/repo-events.yml@main
+    secrets: inherit

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>chodeus/chodeus-ops"]
+}


### PR DESCRIPTION
## Summary

Adopts the shared ops infra from [chodeus/chodeus-ops](https://github.com/chodeus/chodeus-ops). This PR is intentionally minimal — only the low-risk pieces.

- **`.github/workflows/repo-events.yml`** — calls the chodeus-ops reusable that posts Discord notifications for issue/PR/release/discussion events. Uses the repo's `DISCORD_WEBHOOK_URL` secret.
- **`renovate.json`** — extends the `chodeus-ops` Renovate preset (weekend schedule, grouped minor updates, security PRs prioritised, GH Actions pinned to SHA, Docker base digests pinned).

## Not in this PR (phase 2, separate PR)

The CodeQL and Docker jobs inside `codeql-lint.yml` will be migrated in a follow-up PR to call the chodeus-ops reusables (`codeql.yml`, `docker-build.yml`). Keeping that change isolated so this PR can be validated with minimal blast radius — if something breaks, it's localized to the new files.

## Test plan

- [ ] Merge this PR
- [ ] Open any issue, then close it — confirm Discord posts both events
- [ ] Wait ~10 min — confirm the Renovate `Dependency Dashboard` issue appears
- [ ] No existing workflows should change behaviour (Docker + CodeQL still build/publish exactly as before)

## Rollback

`git revert <commit>` — removes both files cleanly. No other workflows touched.