### PR TITLE
ci: add semver Docker tags + tag-push trigger

### DIFF
--- a/.github/workflows/codeql-lint.yml
+++ b/.github/workflows/codeql-lint.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - '*'
+    tags:
+      - 'v*'
     paths:
       - '**.py'
       - '**.js'
@@ -231,6 +233,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/chub
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -241,5 +256,5 @@ jobs:
             BRANCH=${{ steps.get_branch.outputs.BRANCH_NAME }}
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/chub:${{ steps.get_branch.outputs.BRANCH_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

Follow-up to #6 (release-please adoption). Closes the gap where a release-please-generated \`v1.0.1\` tag wouldn't produce a \`:1.0.1\` Docker image — it was only producing \`:main\`.

## Changes (both in \`codeql-lint.yml\`)

### 1. Trigger on tag pushes

```diff
 on:
   push:
     branches:
       - '*'
+    tags:
+      - 'v*'
     paths: ...
```

So \`git push --tags\` (or release-please's auto-tag) now fires the full pipeline.

### 2. \`docker-push\` now uses \`docker/metadata-action\`

Replaces the single hardcoded tag with a metadata-action step that produces multiple tags based on the ref:

| Ref type | Produces tags |
|---|---|
| Branch push (e.g. main) | \`:main\`, \`:sha-abc1234\`, \`:latest\` (main only) |
| Feature branch | \`:feature-name\`, \`:sha-abc1234\` |
| Semver tag \`v1.0.1\` | \`:1.0.1\`, \`:1.0\`, \`:1\`, \`:sha-abc1234\` |
| Semver tag \`v1.0.1\` on main-descended commit | + \`:latest\` |

Existing consumers pointing at \`:main\` see **zero behaviour change** — that tag is still produced by \`type=ref,event=branch\`. Semver tags are purely additive on release events.

## End-to-end flow after merge

1. Make some \`fix:\` or \`feat:\` commits to \`main\`
2. release-please opens a Release PR (\`chore(main): release 1.0.1\`)
3. Merge that PR → release-please tags \`v1.0.1\` + publishes GitHub Release
4. \`codeql-lint.yml\` fires on the tag push → CQ/lint/tests/docker pipeline runs
5. Image published at \`ghcr.io/chodeus/chub:1.0.1\`, \`:1.0\`, \`:1\`, \`:latest\` (latest because the tag is on a main-descended commit)

Downstream users pin to \`:1.0\` for auto-patch updates or \`:1.0.1\` for exact version lock.

## Test plan

- [ ] Merge this PR
- [ ] Verify the next merge-to-main still produces \`:main\` + \`:latest\` as before (should — \`type=ref\` is preserved)
- [ ] After release-please cuts the first release, confirm \`ghcr.io/chodeus/chub:1.0.1\` + \`:1.0\` + \`:1\` all exist in the Packages tab
- [ ] Confirm gating still works (break a lint rule → docker-push is skipped)

## Rollback

\`git revert\` — reverses the 17-line change. Previous behaviour restored (branch-only tags).