### PR TITLE
ci: add Discord failure notification for pipeline

### DIFF
--- a/.github/workflows/codeql-lint.yml
+++ b/.github/workflows/codeql-lint.yml
@@ -258,3 +258,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  notify-failure:
+    needs: [codeql-python, codeql-javascript, backend-lint, backend-smoke, frontend-lint, docker-push]
+    if: failure() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    uses: chodeus/chodeus-ops/.github/workflows/notify-discord.yml@main
+    with:
+      event_type: build
+      status: failure
+      title: "❌ Pipeline failed: ${{ github.ref_name }}"
+      commit_sha: ${{ github.sha }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds one-line Discord alert when any pipeline stage (CodeQL, backend lint/test, frontend lint, or docker-push) fails. Silent on success.

Uniform with [chodeus/BeatsCheck#19](https://github.com/chodeus/BeatsCheck/pull/19) and [chodeus/orpheusmorebetter#33](https://github.com/chodeus/orpheusmorebetter/pull/33).

## What fires

- ✅ All stages succeed → **nothing** (release event covers releases)
- ❌ Any stage fails → one line: *"❌ Pipeline failed: <ref>"* with commit link

The `notify-failure` job `needs:` every upstream stage so you get **one** alert per failed pipeline run, not one per failed job.

## Test plan

- [ ] Merge
- [ ] Next push with passing tests → no Discord
- [ ] Break ruff or a test in a throwaway branch → single alert

## Rollback

`git revert` — removes the single job.