### PR TITLE
chore: bump bcrypt 4.3.0 → 5.0.0 (manual review)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.7.0
 anyio==4.13.0
 apprise==1.9.9
-bcrypt==4.3.0
+bcrypt==5.0.0
 blinker==1.9.0
 certifi==2025.11.12
 charset-normalizer==3.4.7


### PR DESCRIPTION
## Summary

Bumps `bcrypt` from 4.3.0 → 5.0.0.

**Parked per Option C** — leaving open for manual review rather than auto-merging, given the history of bcrypt issues on your stack (Dozzle).

## Usage audit (backend/util/auth.py)

chub uses only 3 bcrypt APIs, all unchanged 4.x → 5.x:

```python
bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
```

## bcrypt 5.0.0 changelog — what's breaking

| Change | Affects chub? |
|---|---|
| Removed `bcrypt.__about__` module | No (not referenced) |
| Dropped Python 3.8 support | No (we're on 3.13) |
| Internal: rewrote hashing in Rust (pyo3) | No (API unchanged) |
| Hash format (`$2b$`) unchanged | ✓ existing stored hashes still validate |

No password rehash is required. Existing users won't notice.

## What to check before merging

1. **Dozzle context** — If chub auth stacks on top of or shares hashes with Dozzle, verify Dozzle isn't pinned to bcrypt 4.x. If it is and they share a password file somehow, don't merge.
2. **Rollout** — after merge, log in once to the deployed chub to confirm password validation still works on a pre-bumped hash.

## Test plan

- [ ] Review diff
- [ ] Merge
- [ ] Deploy
- [ ] Verify login flow on existing user

## Rollback

Single-line `git revert`. Existing hashes remain valid either way.