### PR TITLE
feat(webhooks): persistent dedup, event allow-list, season-aware import, force-reupload

### DIFF
--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -27,7 +27,15 @@ jobs:
 
       - name: Get the new branch name
         id: get_branch
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        run: |
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          # Docker tags can't contain `/` — convention-style names like
+          # feat/foo or fix/bar would otherwise fail with "invalid reference
+          # format". Keep BRANCH_NAME as the human-readable build-arg, but
+          # expose a sanitized BRANCH_TAG for the registry tag.
+          BRANCH_TAG="${BRANCH_NAME//\//-}"
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+          echo "BRANCH_TAG=${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Set build number
         run: echo "BUILD_NUMBER=$(git rev-list --count HEAD)" >> $GITHUB_ENV
@@ -50,4 +58,4 @@ jobs:
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/chub:${{ steps.get_branch.outputs.BRANCH_NAME }}
+            ghcr.io/${{ github.repository_owner }}/chub:${{ steps.get_branch.outputs.BRANCH_TAG }}

--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -11,7 +11,10 @@ permissions:
 jobs:
   docker-tag:
     runs-on: ubuntu-latest
-    if: github.event.ref_type == 'branch'
+    # Run on `create` events for branches, and on manual dispatch (so a
+    # CI fix can be re-tested against an existing branch without having
+    # to delete + recreate it).
+    if: github.event_name == 'workflow_dispatch' || github.event.ref_type == 'branch'
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Single-command Docker, Unraid, and bare-metal options: **[Wiki → Installation]
 
 1. **Use a strong admin password.** First-run enforces 8+ characters; use more. Lose it and you reset with `docker compose run --rm chub python3 main.py --reset-auth`.
 2. **If you want remote access, put CHUB behind a reverse proxy with TLS.** Add a second auth layer in front (Authelia, Authentik, Cloudflare Access). CHUB has built-in login and rate limiting, but no WAF or DDoS protection — it isn't meant to face the open internet alone.
-3. **Set a webhook secret if webhooks leave your LAN.** Configure `general.webhook_secret` in **Settings → General**. Any inbound Sonarr/Radarr/Tautulli webhook must then include it. Without it, webhook URLs are unauthenticated — fine inside a LAN, not fine on the public internet.
+3. **Set a webhook secret if webhooks leave your LAN.** Configure `general.webhook_secret` in **Settings → General**. Any inbound Sonarr/Radarr/Tautulli webhook must then include it. Without it, webhook URLs are unauthenticated — fine inside a LAN, not fine on the public internet. Wiring a webhook into Sonarr/Radarr is documented in the [Webhooks wiki page](https://github.com/chodeus/chub/wiki/Webhooks).
 4. **Pin the image tag for production.** Use a specific digest or date tag instead of `:latest` if you care about reproducible deploys.
 5. **Report vulnerabilities privately.** See [SECURITY.md](SECURITY.md) for the disclosure process.
 

--- a/backend/api/instances.py
+++ b/backend/api/instances.py
@@ -65,6 +65,7 @@ class CreateInstanceRequest(BaseModel):
     api: Optional[str] = None
     type: Optional[str] = None
     apiKey: Optional[str] = None
+    webhook_force_reupload: bool = False
 
     @model_validator(mode="before")
     @classmethod
@@ -87,6 +88,7 @@ class UpdateInstanceRequest(BaseModel):
     api: Optional[str] = None
     type: Optional[str] = None
     apiKey: Optional[str] = None
+    webhook_force_reupload: bool = False
 
     @model_validator(mode="before")
     @classmethod
@@ -777,7 +779,11 @@ async def create_instance(
             )
 
         # Create new instance detail
-        new_instance = InstanceDetail(url=url, api=api_key)
+        new_instance = InstanceDetail(
+            url=url,
+            api=api_key,
+            webhook_force_reupload=data.webhook_force_reupload,
+        )
 
         # Add to appropriate service section
         service_instances[name] = new_instance
@@ -883,7 +889,11 @@ async def update_instance(
             logger.info(f"Renaming instance from '{instance_id}' to '{new_name}'")
 
         # Create/update instance with new values
-        updated_instance = InstanceDetail(url=url, api=api_key)
+        updated_instance = InstanceDetail(
+            url=url,
+            api=api_key,
+            webhook_force_reupload=data.webhook_force_reupload,
+        )
         service_instances[new_name] = updated_instance
 
         # Save updated configuration

--- a/backend/api/webhooks.py
+++ b/backend/api/webhooks.py
@@ -8,8 +8,6 @@ media event notifications, and external service integrations.
 import hashlib
 import hmac
 import json
-import threading
-import time
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -43,10 +41,10 @@ def verify_webhook_secret(request: Request) -> None:
     if not provided or not hmac.compare_digest(expected, provided):
         raise HTTPException(status_code=401, detail="Invalid webhook secret")
 
-# API-layer webhook deduplication
-_webhook_cache: Dict[str, float] = {}
-_webhook_cache_lock = threading.Lock()
-_WEBHOOK_DEBOUNCE_SECONDS = 5
+# Persistent webhook dedup TTL (seconds). Sonarr/Radarr retry on minute-long
+# intervals; the previous in-memory 5s window never caught those and was wiped
+# on restart. Backed by the `webhook_cache` table via `db.webhook_cache`.
+_WEBHOOK_DEDUP_TTL_SECONDS = 600
 
 router = APIRouter(
     prefix="/api/webhooks",
@@ -132,8 +130,9 @@ async def process_poster_webhook(
                 {"event_type": "test"},
             )
 
-        # Deduplicate at API layer before enqueuing
-        if _is_duplicate_webhook(data, logger):
+        # Deduplicate at API layer before enqueuing — persistent rolling
+        # window so Sonarr/Radarr retries are coalesced even across restarts.
+        if _is_duplicate_webhook(data, db, logger):
             return ok(
                 "Duplicate webhook ignored",
                 {"duplicate": True, "status": "debounced"},
@@ -183,15 +182,22 @@ async def process_poster_webhook(
         )
 
 
-def _is_duplicate_webhook(data: Dict[str, Any], logger: Any = None) -> bool:
+def _is_duplicate_webhook(
+    data: Dict[str, Any], db: ChubDB, logger: Any = None
+) -> bool:
     """
-    Check if this webhook is a duplicate using content hashing and debouncing.
+    Check if this webhook is a duplicate against the persistent cache.
 
-    Creates a SHA-256 hash of the media-identifying fields and checks
-    against a time-windowed cache to prevent duplicate job enqueueing.
+    Builds an `item_type` (series/movie) and a SHA-256 of the identifying
+    fields as `item_name`, then asks `db.webhook_cache.is_duplicate` —
+    which sweeps expired rows, checks for a match within the TTL window,
+    and inserts a fresh row when not seen. Restart-safe.
     """
-    # Extract media identifiers for hashing
     media_block = data.get("series") or data.get("movie") or {}
+    item_type = "series" if "series" in data else "movie" if "movie" in data else ""
+    if not item_type:
+        return False
+
     hash_fields = {
         "title": media_block.get("title", ""),
         "year": str(media_block.get("year", "")),
@@ -200,32 +206,21 @@ def _is_duplicate_webhook(data: Dict[str, Any], logger: Any = None) -> bool:
         "imdb_id": str(media_block.get("imdbId", "")),
         "event_type": data.get("eventType", ""),
     }
-
-    content_hash = hashlib.sha256(
+    item_name = hashlib.sha256(
         json.dumps(hash_fields, sort_keys=True).encode()
     ).hexdigest()[:16]
 
-    now = time.time()
-
-    with _webhook_cache_lock:
-        # Clean up old entries
-        expired = [k for k, v in _webhook_cache.items() if now - v > 30]
-        for k in expired:
-            del _webhook_cache[k]
-
-        # Check for duplicate
-        if content_hash in _webhook_cache:
-            elapsed = now - _webhook_cache[content_hash]
-            if elapsed < _WEBHOOK_DEBOUNCE_SECONDS:
-                if logger:
-                    logger.debug(
-                        f"Duplicate webhook debounced (hash={content_hash}, {elapsed:.1f}s ago)"
-                    )
-                return True
-
-        _webhook_cache[content_hash] = now
-
-    return False
+    duplicate = db.webhook_cache.is_duplicate(
+        item_type=item_type,
+        item_name=item_name,
+        ttl_seconds=_WEBHOOK_DEDUP_TTL_SECONDS,
+    )
+    if duplicate and logger:
+        logger.debug(
+            f"Duplicate webhook debounced (item_type={item_type}, "
+            f"item_name={item_name}, ttl={_WEBHOOK_DEDUP_TTL_SECONDS}s)"
+        )
+    return duplicate
 
 
 def _is_test_event(data: Dict[str, Any]) -> bool:

--- a/backend/api/webhooks.py
+++ b/backend/api/webhooks.py
@@ -46,6 +46,20 @@ def verify_webhook_secret(request: Request) -> None:
 # on restart. Backed by the `webhook_cache` table via `db.webhook_cache`.
 _WEBHOOK_DEDUP_TTL_SECONDS = 600
 
+# Sonarr/Radarr fire a wide range of events; only these actually correspond
+# to "new file on disk that needs a poster". `Grab` (download started, file
+# not yet on disk) and lifecycle events (Rename, *FileDelete, HealthIssue,
+# SeriesDelete, MovieDelete) are 200-acknowledged but skipped.
+_ACCEPTED_EVENT_TYPES = frozenset(
+    {
+        "Download",  # Sonarr v3 / Radarr — file imported
+        "MovieAdded",  # Radarr — movie added to library (pre-download)
+        "SeriesAdd",  # Sonarr — series added to library (pre-download)
+        "EpisodeFileImported",  # Sonarr v4+ — episode file imported
+        "MovieFileImported",  # Radarr v5+ — movie file imported
+    }
+)
+
 router = APIRouter(
     prefix="/api/webhooks",
     tags=["Webhooks"],
@@ -128,6 +142,17 @@ async def process_poster_webhook(
             return ok(
                 "Test webhook received successfully",
                 {"event_type": "test"},
+            )
+
+        # Skip events that don't correspond to a new on-disk file (Grab,
+        # *FileDelete, Rename, HealthIssue, etc.). Acknowledge with 200 so
+        # Sonarr/Radarr don't mark the connection broken.
+        event_type = data.get("eventType", "")
+        if event_type and event_type not in _ACCEPTED_EVENT_TYPES:
+            logger.debug(f"Ignoring unsupported event type: {event_type}")
+            return ok(
+                "Event type not supported — webhook ignored",
+                {"event_type": event_type, "status": "skipped"},
             )
 
         # Deduplicate at API layer before enqueuing — persistent rolling

--- a/backend/api/webhooks.py
+++ b/backend/api/webhooks.py
@@ -223,13 +223,16 @@ def _is_duplicate_webhook(
     if not item_type:
         return False
 
+    # Hash on media identity only — NOT eventType. Sonarr v4 fires both
+    # `Download` and `EpisodeFileImported` for the same import; including
+    # eventType in the hash would make the second event a different
+    # fingerprint and run the pipeline twice for one on-disk change.
     hash_fields = {
         "title": media_block.get("title", ""),
         "year": str(media_block.get("year", "")),
         "tmdb_id": str(media_block.get("tmdbId", "")),
         "tvdb_id": str(media_block.get("tvdbId", "")),
         "imdb_id": str(media_block.get("imdbId", "")),
-        "event_type": data.get("eventType", ""),
     }
     item_name = hashlib.sha256(
         json.dumps(hash_fields, sort_keys=True).encode()

--- a/backend/util/config.py
+++ b/backend/util/config.py
@@ -37,6 +37,13 @@ class InstanceDetail(BaseModel):
     url: Optional[str] = ""
     api: Optional[str] = ""
     enabled: bool = True
+    # When True, webhook-triggered uploads from this instance bypass the
+    # SHA-256 hash dedup in PosterUploader so an unchanged-on-disk poster
+    # is still re-pushed to Plex. Useful when Plex itself has been wiped
+    # or when the user is actively re-curating a particular library.
+    # Only meaningful for radarr / sonarr / lidarr (the instances that
+    # fire webhooks); harmless on plex entries.
+    webhook_force_reupload: bool = False
 
 
 class InstancesConfig(BaseModel):
@@ -197,9 +204,12 @@ class GeneralConfig(BaseModel):
     log_level: str = "info"
     update_notifications: bool = False
     max_logs: int = 9
+    # Plex's recently-added scan can lag 5+ minutes behind a Sonarr/Radarr
+    # import under load. Defaults give ~5.5 min of total search:
+    #   30s warmup + 10 attempts × 30s = 330s
     webhook_initial_delay: int = 30
-    webhook_retry_delay: int = 60
-    webhook_max_retries: int = 3
+    webhook_retry_delay: int = 30
+    webhook_max_retries: int = 10
     webhook_secret: str = ""
     duplicate_exclude_groups: List[Any] = Field(default_factory=list)
 

--- a/backend/util/database/__init__.py
+++ b/backend/util/database/__init__.py
@@ -16,6 +16,7 @@ from .poster_cache import PosterCache
 from .run_state import RunState
 from .schema import SchemaManager
 from .stats import Stats
+from .webhook_cache import WebhookCache
 from .worker import DBWorker
 
 
@@ -185,6 +186,11 @@ class ChubDB:
         return self._get_interface("holiday", HolidayStatus)
 
     @property
+    def webhook_cache(self) -> WebhookCache:
+        """Access to persistent webhook dedup cache."""
+        return self._get_interface("webhook_cache", WebhookCache)
+
+    @property
     def worker(self) -> DBWorker:
         """Access to default worker operations."""
         return self._get_interface(
@@ -289,5 +295,6 @@ __all__ = [
     "DBWorker",
     "HolidayStatus",
     "MediaCache",
+    "WebhookCache",
     "with_database",
 ]

--- a/backend/util/database/schema.py
+++ b/backend/util/database/schema.py
@@ -387,6 +387,29 @@ class SchemaManager:
         )
         self._add_table(system_health_snapshots)
 
+        # Webhook dedup cache — persistent rolling window so Sonarr/Radarr
+        # retries (minutes apart) get coalesced even across restarts.
+        # UNIQUE on (item_type, item_name) with timestamp-based eviction
+        # handled by the WebhookCache interface.
+        webhook_cache = TableDefinition(
+            name="webhook_cache",
+            columns=[
+                ColumnDefinition("id", "INTEGER", primary_key=True, nullable=False),
+                ColumnDefinition("item_type", "TEXT", nullable=False),
+                ColumnDefinition("item_name", "TEXT", nullable=False),
+                ColumnDefinition(
+                    "timestamp", "TEXT", nullable=False, default="CURRENT_TIMESTAMP"
+                ),
+            ],
+            constraints=[
+                "UNIQUE (item_type, item_name)",
+            ],
+            indexes=[
+                "CREATE INDEX IF NOT EXISTS webhook_cache_timestamp_idx ON webhook_cache (timestamp)",
+            ],
+        )
+        self._add_table(webhook_cache)
+
         # Media edit history — audit trail for user-initiated metadata edits.
         media_edit_history = TableDefinition(
             name="media_edit_history",

--- a/backend/util/database/webhook_cache.py
+++ b/backend/util/database/webhook_cache.py
@@ -1,0 +1,85 @@
+# util/database/webhook_cache.py
+
+import datetime
+from typing import Optional
+
+from .db_base import DatabaseBase
+
+
+class WebhookCache(DatabaseBase):
+    """
+    Persistent webhook dedup cache.
+
+    Sonarr/Radarr retry failed webhooks minutes apart; an in-memory
+    debounce window (seconds) won't catch those, and is wiped on restart.
+    This table holds a rolling window keyed on (item_type, item_name)
+    with a configurable TTL — defaults to 600s.
+    """
+
+    DEFAULT_TTL_SECONDS = 600
+
+    def is_duplicate(
+        self, item_type: str, item_name: str, ttl_seconds: int = DEFAULT_TTL_SECONDS
+    ) -> bool:
+        """
+        Check whether `(item_type, item_name)` was seen within `ttl_seconds`.
+
+        Behaviour:
+        - Sweeps rows older than the TTL on every call (cheap; the index
+          on `timestamp` keeps the scan small).
+        - If a non-expired row exists, returns True.
+        - Otherwise inserts a fresh row and returns False.
+
+        IntegrityError on the UNIQUE constraint is treated as a duplicate
+        (race window between two concurrent webhook calls for the same item).
+        """
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cutoff_iso = (
+            now - datetime.timedelta(seconds=ttl_seconds)
+        ).isoformat()
+        now_iso = now.isoformat()
+
+        with self.get_connection() as conn:
+            conn.execute(
+                "DELETE FROM webhook_cache WHERE timestamp < ?", (cutoff_iso,)
+            )
+
+            existing = conn.execute(
+                "SELECT id FROM webhook_cache WHERE item_type = ? AND item_name = ?",
+                (item_type, item_name),
+            ).fetchone()
+
+            if existing:
+                conn.commit()
+                return True
+
+            try:
+                conn.execute(
+                    "INSERT INTO webhook_cache (item_type, item_name, timestamp) "
+                    "VALUES (?, ?, ?)",
+                    (item_type, item_name, now_iso),
+                )
+                conn.commit()
+                return False
+            except Exception:
+                conn.rollback()
+                return True
+
+    def clear(self) -> None:
+        """Drop every row (testing/dev only)."""
+        self.execute_query("DELETE FROM webhook_cache")
+
+    def count(self) -> int:
+        row = self.execute_query(
+            "SELECT COUNT(*) AS n FROM webhook_cache", fetch_one=True
+        )
+        return int(row["n"]) if row else 0
+
+    def last_seen(self, item_type: str, item_name: str) -> Optional[str]:
+        row = self.execute_query(
+            "SELECT timestamp FROM webhook_cache "
+            "WHERE item_type = ? AND item_name = ?",
+            (item_type, item_name),
+            fetch_one=True,
+        )
+        return row["timestamp"] if row else None

--- a/backend/util/job_processor.py
+++ b/backend/util/job_processor.py
@@ -249,7 +249,18 @@ def _process_webhook_job(
             log.info(f"[JOB:{job_id}] Webhook processing successful")
 
             if rename_result.get("output"):
-                _handle_post_rename_actions(rename_result, renamer, logger, job_id)
+                # Honour `webhook_force_reupload` on the originating *arr
+                # instance — when set, the queued upload job bypasses the
+                # uploader's hash-equal short-circuit so an unchanged
+                # poster still gets re-pushed to Plex.
+                force_upload = _instance_force_reupload(instance_info)
+                _handle_post_rename_actions(
+                    rename_result,
+                    renamer,
+                    logger,
+                    job_id,
+                    force_upload=force_upload,
+                )
 
             return {
                 "success": True,
@@ -457,8 +468,11 @@ def _process_upload_posters_job(
             "error_code": "MISSING_MANIFEST",
         }
 
+    force = bool(payload.get("force", False))
     with ChubDB(logger=logger) as db:
-        uploader = PosterUploader(db=db, logger=logger, manifest=manifest)
+        uploader = PosterUploader(
+            db=db, logger=logger, manifest=manifest, force=force
+        )
         result = uploader.run()
 
     if result.get("success"):
@@ -477,7 +491,11 @@ def _process_upload_posters_job(
 
 
 def _handle_post_rename_actions(
-    rename_result: Dict[str, Any], renamer, logger, job_id: int
+    rename_result: Dict[str, Any],
+    renamer,
+    logger,
+    job_id: int,
+    force_upload: bool = False,
 ) -> None:
     """
     Handle notifications and uploads after successful rename.
@@ -487,6 +505,9 @@ def _handle_post_rename_actions(
         renamer: PosterRenamerr instance
         logger: Logger instance
         job_id: Job ID for tracking
+        force_upload: When True, queues the upload job with `force=True` so
+            the uploader skips its hash-equal short-circuit. Webhook flows
+            set this from the *arr instance's `webhook_force_reupload`.
     """
     log = logger.get_adapter("POST_RENAME")
 
@@ -512,7 +533,7 @@ def _handle_post_rename_actions(
         # Queue upload job if Plex instances are enabled
         plex_enabled = _check_plex_upload_enabled(renamer.config)
         if plex_enabled and manifest:
-            _queue_upload_job(manifest, logger, job_id)
+            _queue_upload_job(manifest, logger, job_id, force=force_upload)
         else:
             log.info(
                 f"[JOB:{job_id}] Plex upload not enabled or no manifest - task complete"
@@ -520,6 +541,24 @@ def _handle_post_rename_actions(
 
     except Exception as e:
         log.error(f"[JOB:{job_id}] Error in post-rename actions: {e}")
+
+
+def _instance_force_reupload(instance_info: Dict[str, Any]) -> bool:
+    """
+    Return the configured `webhook_force_reupload` for a Sonarr/Radarr/Lidarr
+    instance identified by `instance_info`. Falls back to False on any
+    config-loading or attribute-lookup error so a malformed config can never
+    silently force-upload everything.
+    """
+    try:
+        from backend.util.config import load_config
+
+        cfg = load_config()
+        bucket = getattr(cfg.instances, instance_info.get("type", ""), None) or {}
+        details = bucket.get(instance_info.get("name", ""))
+        return bool(getattr(details, "webhook_force_reupload", False))
+    except Exception:
+        return False
 
 
 def _check_plex_upload_enabled(config) -> bool:
@@ -761,7 +800,9 @@ def _process_module_run_job(
         }
 
 
-def _queue_upload_job(manifest: Dict[str, Any], logger, job_id: int) -> None:
+def _queue_upload_job(
+    manifest: Dict[str, Any], logger, job_id: int, force: bool = False
+) -> None:
     """
     Queue a poster upload job.
 
@@ -769,11 +810,15 @@ def _queue_upload_job(manifest: Dict[str, Any], logger, job_id: int) -> None:
         manifest: Upload manifest data
         logger: Logger instance
         job_id: Current job ID for tracking
+        force: When True, the uploader bypasses its hash-equal short-circuit
+            so unchanged posters still get re-pushed to Plex. Set by webhook
+            flows when the originating *arr instance has
+            `webhook_force_reupload` enabled.
     """
     log = logger.get_adapter("UPLOAD_POSTERS")
 
     try:
-        upload_payload = {"manifest": manifest}
+        upload_payload = {"manifest": manifest, "force": bool(force)}
 
         with ChubDB(logger=logger) as db:
             result = db.worker.enqueue_job(

--- a/backend/util/job_processor.py
+++ b/backend/util/job_processor.py
@@ -132,6 +132,7 @@ def _process_webhook_job(
 
         instance_info = validation_result["instance_info"]
         media_id = validation_result["media_id"]
+        webhook_season = validation_result.get("season_number")
 
         # Helper function to process the media item
         def _process_media_item(db_context):
@@ -223,8 +224,24 @@ def _process_webhook_job(
         # Wait for item to appear in Plex before processing posters
         processor.wait_for_plex_availability(media["title"], year=media.get("year"))
 
-        # Run poster rename on the stored media
+        # Run poster rename on the stored media. For Sonarr Download /
+        # EpisodeFileImported events the payload carries the affected
+        # season; narrow `media_items` to (show row + matching season row)
+        # so the renamer only re-matches what actually changed.
         media_items = stored_media if isinstance(stored_media, list) else [stored_media]
+        if webhook_season is not None and instance_info["type"] == "sonarr":
+            focused = [
+                item
+                for item in media_items
+                if item.get("season_number") in (None, webhook_season)
+            ]
+            if focused:
+                log.debug(
+                    f"[JOB:{job_id}] Narrowed {len(media_items)} stored rows to "
+                    f"{len(focused)} for season {webhook_season}"
+                )
+                media_items = focused
+
         renamer = PosterRenamerr(logger=logger)
         rename_result = renamer.run_poster_rename_adhoc(media_items)
 

--- a/backend/util/webhook_processor.py
+++ b/backend/util/webhook_processor.py
@@ -60,6 +60,8 @@ class WebhookProcessor:
                 "error_code": "NO_INSTANCE",
             }
 
+        season_number = self._extract_season_number(webhook_data)
+
         return {
             "success": True,
             "message": "Webhook validated successfully",
@@ -67,6 +69,7 @@ class WebhookProcessor:
             "media_type": media_type,
             "media_id": media_id,
             "instance_info": instance_info,
+            "season_number": season_number,
         }
 
     def _extract_media_block(
@@ -87,6 +90,26 @@ class WebhookProcessor:
             return webhook_data["movie"], "movie", webhook_data["movie"].get("id")
         else:
             return None, None, None
+
+    @staticmethod
+    def _extract_season_number(webhook_data: dict) -> Optional[int]:
+        """
+        For Sonarr Download / EpisodeFileImported events, pull the season
+        number from `episodes[0].seasonNumber` so downstream processing can
+        focus the asset match on the correct season instead of re-matching
+        the whole show.
+
+        Returns None for movies, series-add events, or payloads without an
+        episodes list — callers treat None as "not season-scoped".
+        """
+        episodes = webhook_data.get("episodes") or []
+        if not episodes:
+            return None
+        season = episodes[0].get("seasonNumber")
+        try:
+            return int(season) if season is not None else None
+        except (TypeError, ValueError):
+            return None
 
     def _find_arr_instance(self, client_info: Optional[dict] = None) -> dict:
         """

--- a/backend/util/webhook_processor.py
+++ b/backend/util/webhook_processor.py
@@ -1,25 +1,22 @@
 # util/webhook_processor.py
 
-import hashlib
-import json
-import threading
 import time
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
 from backend.util.config import load_config
-from backend.util.database import ChubDB
 
 
 class WebhookProcessor:
     """
     Clean webhook processor that only handles validation and routing.
     Business logic is delegated to other components.
-    """
 
-    # Simple deduplication cache
-    _cache = {}
-    _cache_lock = threading.Lock()
+    Dedup lives in `db.webhook_cache` (persistent, restart-safe) and is
+    handled at the API layer in `backend/api/webhooks.py` before a job is
+    ever enqueued. This class only validates payloads and waits for Plex
+    availability.
+    """
 
     def __init__(self, logger):
         self.logger = logger
@@ -28,63 +25,6 @@ class WebhookProcessor:
         self.initial_delay = getattr(general, "webhook_initial_delay", 30)
         self.retry_delay = getattr(general, "webhook_retry_delay", 60)
         self.max_retries = getattr(general, "webhook_max_retries", 3)
-
-    def process_webhook(
-        self, webhook_data: dict, client_info: Optional[dict] = None
-    ) -> dict:
-        """
-        Process webhook and enqueue job for background processing.
-
-        Args:
-            webhook_data: Raw webhook data from ARR
-            client_info: Optional client info from API layer
-
-        Returns:
-            dict: Standardized success/failure response
-        """
-        log = self.logger.get_adapter("WEBHOOK")
-
-        # Validate and extract basic info
-        validation_result = self._validate_webhook(webhook_data, client_info)
-        if not validation_result["success"]:
-            return validation_result
-
-        # Check for duplicates (simple debouncing)
-        if self._is_duplicate(validation_result["cache_key"], webhook_data):
-            log.debug("Skipping duplicate webhook (debounced)")
-            return {
-                "success": True,
-                "message": "Webhook debounced (duplicate)",
-                "data": {"debounced": True},
-            }
-
-        # Enqueue job for background processing
-        job_payload = {
-            "webhook_data": webhook_data,
-            "client_info": client_info,
-            "instance_info": validation_result["instance_info"],
-        }
-
-        with ChubDB(logger=self.logger) as db:
-            enqueue_result = db.worker.enqueue_job(
-                table_name="jobs", payload=job_payload, job_type="webhook"
-            )
-
-        if enqueue_result["success"]:
-            job_id = enqueue_result["data"]["job_id"]
-            log.info(f"Webhook enqueued as job {job_id}")
-            return {
-                "success": True,
-                "message": "Webhook enqueued for processing",
-                "data": {"job_id": job_id},
-            }
-        else:
-            log.error(f"Failed to enqueue webhook: {enqueue_result['message']}")
-            return {
-                "success": False,
-                "message": "Failed to enqueue webhook",
-                "error_code": "ENQUEUE_FAILED",
-            }
 
     def _validate_webhook(
         self, webhook_data: dict, client_info: Optional[dict] = None
@@ -120,9 +60,6 @@ class WebhookProcessor:
                 "error_code": "NO_INSTANCE",
             }
 
-        # Create cache key for deduplication
-        cache_key = (instance_info["type"], instance_info["name"], media_type, media_id)
-
         return {
             "success": True,
             "message": "Webhook validated successfully",
@@ -130,7 +67,6 @@ class WebhookProcessor:
             "media_type": media_type,
             "media_id": media_id,
             "instance_info": instance_info,
-            "cache_key": cache_key,
         }
 
     def _extract_media_block(
@@ -212,54 +148,6 @@ class WebhookProcessor:
                     }
 
         return {"found": False, "error": "No matching instance"}
-
-    def _is_duplicate(self, cache_key: tuple, webhook_data: dict) -> bool:
-        """
-        Check if this webhook is a duplicate (simple debouncing).
-
-        Args:
-            cache_key: Unique cache key for this webhook
-            webhook_data: Raw webhook data
-
-        Returns:
-            bool: True if duplicate
-        """
-        media_block, _, _ = self._extract_media_block(webhook_data)
-        if not media_block:
-            return False
-
-        # Simple hash of relevant fields
-        hash_data = {
-            k: media_block.get(k)
-            for k in ["title", "year", "tmdb_id", "tvdb_id", "imdb_id"]
-            if k in media_block
-        }
-        content_hash = hashlib.sha256(
-            json.dumps(hash_data, sort_keys=True, default=str).encode("utf-8")
-        ).hexdigest()
-
-        debounce_window = getattr(self, "initial_delay", 5)
-        if debounce_window > 10:
-            debounce_window = (
-                5  # Keep dedup window short, use initial_delay for processing
-            )
-
-        now = time.time()
-        with self._cache_lock:
-            if cache_key in self._cache:
-                prev_hash, prev_time = self._cache[cache_key]
-                if prev_hash == content_hash and (now - prev_time) < debounce_window:
-                    return True
-
-            self._cache[cache_key] = (content_hash, now)
-
-            # Simple cleanup - remove entries older than 30 seconds
-            cutoff = now - 30
-            expired_keys = [k for k, (_, t) in self._cache.items() if t < cutoff]
-            for k in expired_keys:
-                del self._cache[k]
-
-        return False
 
     def wait_for_plex_availability(self, media_title: str, year=None) -> bool:
         """

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,10 +182,14 @@ persist result to jobs table, emit SSE update
 
 ## Webhooks
 
-`backend/api/webhooks.py` + `backend/util/webhook_processor.py`:
+`backend/api/webhooks.py` + `backend/util/webhook_processor.py`. End-user setup (where to copy the URL from, how to wire it into Sonarr/Radarr, accepted events, troubleshooting) lives in the [Webhooks wiki page](https://github.com/chodeus/chub/wiki/Webhooks); this section covers the internal model.
 
-- Accepts Sonarr/Radarr/Tautulli event payloads.
+- Accepts Sonarr/Radarr/Tautulli event payloads. The accepted-event allow-list is `Download`, `MovieAdded`, `SeriesAdd`, `EpisodeFileImported`, `MovieFileImported`. `Test` events are 200-acked separately. Anything else (Grab, *FileDelete, Rename, HealthIssue, *Delete) is 200-acked and dropped before dedup.
 - Optional shared-secret auth: if `general.webhook_secret` is set, requests must provide either `X-Webhook-Secret` header or `?secret=` query param (HMAC-compared). If unset, webhooks are accepted unauthenticated (matches Sonarr/Radarr's default posture).
+- Dedup is persistent: `webhook_cache` table with a 600s TTL keyed on `(item_type, sha256(identifying fields))`. Survives restart so Sonarr/Radarr retries (minutes apart) coalesce.
+- Sonarr `Download` / `EpisodeFileImported` payloads carry `episodes[*].seasonNumber`; the validator extracts it and the webhook job narrows `stored_media` to `(show row + matching season row)` so the renamer only re-walks what actually changed.
+- Each radarr/sonarr/lidarr `InstanceDetail` carries `webhook_force_reupload` (default `False`). When set, webhook-triggered uploads from that instance bypass the uploader's hash-equal short-circuit so an unchanged-on-disk poster is still re-pushed to Plex.
+- Recently-added retry: after enqueue, `wait_for_plex_availability` polls each Plex section's recently-added list with `webhook_initial_delay` warmup + `webhook_max_retries × webhook_retry_delay` (defaults 30s + 10×30s = ~5.5 min).
 - Each inbound webhook creates a job with origin metadata — enables downstream filtering and auditing.
 
 ---

--- a/frontend/src/pages/settings/GeneralSettingsPage.jsx
+++ b/frontend/src/pages/settings/GeneralSettingsPage.jsx
@@ -81,6 +81,9 @@ export const GeneralSettingsPage = () => {
                 log_level: 'info',
                 max_logs: 5,
                 update_notifications: false,
+                webhook_initial_delay: 30,
+                webhook_retry_delay: 30,
+                webhook_max_retries: 10,
             },
         };
         setFormData(initialData);

--- a/frontend/src/pages/settings/GeneralSettingsPage.jsx
+++ b/frontend/src/pages/settings/GeneralSettingsPage.jsx
@@ -84,6 +84,7 @@ export const GeneralSettingsPage = () => {
                 webhook_initial_delay: 30,
                 webhook_retry_delay: 30,
                 webhook_max_retries: 10,
+                webhook_secret: '',
             },
         };
         setFormData(initialData);

--- a/frontend/src/pages/settings/InstancesPage.jsx
+++ b/frontend/src/pages/settings/InstancesPage.jsx
@@ -206,6 +206,7 @@ export const InstancesPage = () => {
                 name: instanceName,
                 url: instanceUrl,
                 api: instanceConfig?.api || '',
+                webhook_force_reupload: !!instanceConfig?.webhook_force_reupload,
             });
             setFormErrors({});
             setEditModalOpen(true);
@@ -231,14 +232,16 @@ export const InstancesPage = () => {
      */
     const validateForm = useCallback(() => {
         const errors = {};
-        INSTANCE_SCHEMA.forEach(field => {
+        INSTANCE_SCHEMA.filter(
+            field => !field.serviceTypes || field.serviceTypes.includes(modalServiceType)
+        ).forEach(field => {
             if (field.required && !formData[field.key]) {
                 errors[field.key] = `${field.label} is required`;
             }
         });
         setFormErrors(errors);
         return Object.keys(errors).length === 0;
-    }, [formData]);
+    }, [formData, modalServiceType]);
 
     /**
      * Handle form submission for Add/Edit
@@ -273,6 +276,7 @@ export const InstancesPage = () => {
                             name: formData.name,
                             url: formData.url,
                             api: formData.api,
+                            webhook_force_reupload: !!formData.webhook_force_reupload,
                         };
 
                         if (isEdit) {
@@ -617,13 +621,19 @@ export const InstancesPage = () => {
                 </Modal.Header>
                 <Modal.Body>
                     <div className="flex flex-col gap-4">
-                        {INSTANCE_SCHEMA.map(field => {
+                        {INSTANCE_SCHEMA.filter(
+                            field =>
+                                !field.serviceTypes || field.serviceTypes.includes(modalServiceType)
+                        ).map(field => {
                             const FieldComponent = FieldRegistry.getField(field.type);
+                            const isToggle = field.type === 'toggle' || field.type === 'check_box';
                             return (
                                 <FieldComponent
                                     key={field.key}
                                     field={field}
-                                    value={formData[field.key] || ''}
+                                    value={
+                                        isToggle ? !!formData[field.key] : formData[field.key] || ''
+                                    }
                                     onChange={value => handleFieldChange(field.key, value)}
                                     errorMessage={formErrors[field.key]}
                                     highlightInvalid={!!formErrors[field.key]}
@@ -658,13 +668,19 @@ export const InstancesPage = () => {
                 </Modal.Header>
                 <Modal.Body>
                     <div className="flex flex-col gap-4">
-                        {INSTANCE_SCHEMA.map(field => {
+                        {INSTANCE_SCHEMA.filter(
+                            field =>
+                                !field.serviceTypes || field.serviceTypes.includes(modalServiceType)
+                        ).map(field => {
                             const FieldComponent = FieldRegistry.getField(field.type);
+                            const isToggle = field.type === 'toggle' || field.type === 'check_box';
                             return (
                                 <FieldComponent
                                     key={field.key}
                                     field={field}
-                                    value={formData[field.key] || ''}
+                                    value={
+                                        isToggle ? !!formData[field.key] : formData[field.key] || ''
+                                    }
                                     onChange={value => handleFieldChange(field.key, value)}
                                     errorMessage={formErrors[field.key]}
                                     highlightInvalid={!!formErrors[field.key]}

--- a/frontend/src/utils/constants/general_settings_schema.js
+++ b/frontend/src/utils/constants/general_settings_schema.js
@@ -50,6 +50,14 @@ export const GENERAL_SETTINGS_SCHEMA = [
                 description:
                     'Maximum Plex recently-added checks per webhook before the upload step is skipped for this run.',
             },
+            {
+                key: 'webhook_secret',
+                label: 'Webhook secret',
+                type: 'password',
+                placeholder: 'Leave blank to accept unauthenticated webhooks',
+                description:
+                    'Optional shared secret. When set, every inbound webhook must send `X-Webhook-Secret: <value>` (or `?secret=<value>`) or it is rejected with 401. Recommended if your webhook URL is reachable outside your LAN.',
+            },
         ],
     },
 ];

--- a/frontend/src/utils/constants/general_settings_schema.js
+++ b/frontend/src/utils/constants/general_settings_schema.js
@@ -26,6 +26,30 @@ export const GENERAL_SETTINGS_SCHEMA = [
                 type: 'check_box',
                 description: 'Enable notifications for available updates.',
             },
+            {
+                key: 'webhook_initial_delay',
+                label: 'Webhook initial delay (seconds)',
+                type: 'number',
+                placeholder: '30',
+                description:
+                    'How long to wait after a webhook fires before the first Plex recently-added check. Gives Plex time to scan the new file.',
+            },
+            {
+                key: 'webhook_retry_delay',
+                label: 'Webhook retry delay (seconds)',
+                type: 'number',
+                placeholder: '30',
+                description:
+                    "How long to sleep between Plex recently-added checks if the new item still isn't visible.",
+            },
+            {
+                key: 'webhook_max_retries',
+                label: 'Webhook max retries',
+                type: 'number',
+                placeholder: '10',
+                description:
+                    'Maximum Plex recently-added checks per webhook before the upload step is skipped for this run.',
+            },
         ],
     },
 ];

--- a/frontend/src/utils/constants/instance_schema.js
+++ b/frontend/src/utils/constants/instance_schema.js
@@ -23,4 +23,14 @@ export const INSTANCE_SCHEMA = [
         placeholder: 'Paste API Key',
         description: 'API Key for this instance.',
     },
+    {
+        key: 'webhook_force_reupload',
+        label: 'Force re-upload on webhook',
+        type: 'toggle',
+        // Plex doesn't fire webhooks at CHUB; the flag only matters for the
+        // *arr that triggered the import.
+        serviceTypes: ['radarr', 'sonarr', 'lidarr'],
+        description:
+            "When ON, webhooks from this instance bypass CHUB's file-hash skip and re-push the poster to Plex even if it hasn't changed on disk. Useful after a Plex wipe or while actively re-curating a library.",
+    },
 ];


### PR DESCRIPTION
## Summary

Hardens the existing webhook pipeline. No new modules — same rename → border-replace → Plex-upload chain, just better dedup, tighter event handling, and finer control.

- **Persistent dedup** via `webhook_cache` table (600s TTL on `(item_type, sha256(media identity))`). Restart-safe; coalesces Sonarr/Radarr retries that the old in-memory 5s window missed. Hash is media-only — Sonarr v4's `Download` + `EpisodeFileImported` for one import dedup as duplicates.
- **Event allow-list:** only `Download`, `MovieAdded`, `SeriesAdd`, `EpisodeFileImported`, `MovieFileImported` drive a job. `Grab`, `Rename`, `*FileDelete`, `HealthIssue`, `*Delete`, etc. get a 200 ack and are dropped before dedup. `Test` events still ack as before.
- **Season-aware import:** Sonarr `Download` / `EpisodeFileImported` payloads with `episodes[*].seasonNumber` narrow `stored_media` to `(show row + matching season row)` so the renamer only re-walks one season.
- **Retry budget bumped** to `30 + 10×30 = ~5.5 min` (was `30 + 3×60 = 3.5 min`). Existing `config.yml` overrides unchanged.
- **Per-instance `webhook_force_reupload`** on Radarr/Sonarr/Lidarr instances. When ON, webhook-fired uploads bypass the SHA-256 hash-equal short-circuit and re-push the poster even if it hasn't changed on disk. Useful after a Plex wipe or while re-curating a library.
- **UI exposure** for everything: per-instance toggle in the Add/Edit Instance modal; retry knobs and webhook secret as fields in **Settings → General**. Aligns the UI with what the docs already claimed.
- **Docs** refreshed in `docs/architecture.md` and the [Webhooks wiki page](https://github.com/chodeus/chub/wiki/Webhooks).
- Dead code removed: unused `WebhookProcessor.process_webhook` and `_is_duplicate` helpers.

## Test plan

- [x] `ruff check backend/` clean
- [x] `npm run lint` + `npx prettier --check` clean
- [x] Integration sanity assertions (allow-list contents, force-reupload plumbing, no dead code)
- [x] Docker tag build green: ghcr.io/chodeus/chub:feat-webhook-hardening
- [ ] **Live test on Unraid (192.168.2.206:8060)**: pull the new image, fire a real Sonarr "On Import" against a known item, verify (a) job created, (b) renamer ran on show + only the affected season, (c) Plex upload pushed posters
- [ ] **Live test of force-reupload**: enable `webhook_force_reupload` on one Sonarr instance via the UI, fire a webhook for an item whose poster is unchanged, verify upload happened anyway
- [ ] **Live test of webhook secret**: set a secret in Settings → General, fire a webhook without the header → 401, fire with the header → 200

## Notes

- A small CI workflow fix went in alongside (`on-branch-create.yml` now sanitizes `/` in branch names for Docker tags, and respects `workflow_dispatch`).
- This branch already has 8 functional commits + 2 CI fixups. Pre-merge squash is fine if you prefer a single commit on main.