### PR TITLE
fix(settings): correct source_dirs priority tooltip direction

### DIFF
--- a/frontend/src/utils/constants/settings_schema.js
+++ b/frontend/src/utils/constants/settings_schema.js
@@ -152,7 +152,7 @@ export const SETTINGS_SCHEMA = [
                 section: 'Source',
                 required: true,
                 description:
-                    'Folders scanned for poster assets. Drag to set priority — earlier directories win when multiple sources have a poster for the same item.',
+                    'Folders scanned for poster assets. Drag to set priority — later directories win when multiple sources have a poster for the same item (bottom of the list takes precedence).',
             },
             {
                 key: 'sync_posters',
@@ -257,7 +257,7 @@ export const SETTINGS_SCHEMA = [
                 type: 'dirlist_dragdrop',
                 section: 'Paths',
                 description:
-                    'Folders scanned for poster assets when Border Replacerr is run on its own (not via Poster Renamerr). Drag to set priority — earlier directories win when multiple sources have a poster for the same item.',
+                    'Folders scanned for poster assets when Border Replacerr is run on its own (not via Poster Renamerr). Drag to set priority — later directories win when multiple sources have a poster for the same item (bottom of the list takes precedence).',
             },
             {
                 key: 'destination_dir',


### PR DESCRIPTION
## Summary
- The Poster Renamerr and Border Replacerr "Source Directories" tooltips claimed *earlier* directories win when multiple sources have a poster for the same item. The actual code does the opposite.
- In `merge_assets` (`backend/modules/poster_renamerr.py:647-719`) each asset is processed by deleting any existing `poster_cache` row that matches by id (`poster_cache.py:176`) or normalized title (`poster_cache.py:193`) and then upserting the new one. Iterating `source_dirs` top-to-bottom means each later directory overwrites whatever the earlier one wrote — so the **bottom** of the list wins (matching DAPS).
- Updated both tooltips in `frontend/src/utils/constants/settings_schema.js` to say "later directories win… bottom of the list takes precedence."

## Test plan
- [ ] Open Settings → Poster Renamerr → Source Directories and confirm the tooltip reads "later directories win… (bottom of the list takes precedence)."
- [ ] Open Settings → Border Replacerr → Source Directories and confirm the same wording.
- [ ] Configure two source dirs that both contain a poster for the same title, run Poster Renamerr, and verify the poster from the **bottom** entry is the one that ends up in the destination.

https://claude.ai/code/session_01W1HWLnmMXaL4q5CnknxzD6

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1HWLnmMXaL4q5CnknxzD6)_