### PR TITLE
fix(notifications): wire Discord/Notifiarr/Email end-to-end

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -39,6 +39,7 @@ from backend.util.auth import decode_access_token
 from backend.util.config import ConfigError, load_config
 from backend.util.database import ChubDB
 from backend.util.job_processor import process_job
+from backend.util.notification import install_error_notify_handler
 
 
 # Paths that do NOT require authentication
@@ -137,6 +138,20 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             log.debug("Starting FastAPI application...")
 
         app.state.started_at = time.time()
+
+        try:
+            startup_config = load_config()
+            handler = install_error_notify_handler(startup_config, logger=logger)
+            if handler and log:
+                log.info(
+                    "ErrorNotifyHandler attached to root logger — ERROR-level logs "
+                    "will be forwarded to the 'main' notification target."
+                )
+        except ConfigError:
+            if log:
+                log.debug(
+                    "Skipped ErrorNotifyHandler setup — config not loadable yet."
+                )
 
         # CREATE SHARED DATABASE INSTANCE FOR ALL API ENDPOINTS
         try:

--- a/backend/util/notification.py
+++ b/backend/util/notification.py
@@ -18,7 +18,6 @@ from ratelimit import limits, sleep_and_retry
 class NotifiarrConfig:
     webhook: str
     channel_id: int
-    bot_name: Optional[str] = None
     color: Optional[str] = None
 
 
@@ -422,7 +421,6 @@ class NotificationManager:
                         target_data["notifiarr"] = {
                             "webhook": hook,
                             "channel_id": cid_int,
-                            "bot_name": target.get("bot_name") or None,
                             "color": target.get("color") or None,
                         }
                     else:

--- a/backend/util/notification.py
+++ b/backend/util/notification.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import random
+import threading
 import traceback
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -17,13 +18,24 @@ from ratelimit import limits, sleep_and_retry
 class NotifiarrConfig:
     webhook: str
     channel_id: int
+    bot_name: Optional[str] = None
+    color: Optional[str] = None
+
+
+@dataclass
+class DiscordConfig:
+    webhook: str
+    bot_name: Optional[str] = None
+    color: Optional[str] = None
 
 
 class NotificationManager:
-    def __init__(self, config, logger, module_name="main"):
+    def __init__(self, config, logger, module_name="main", format_module_name=None):
         self.config = config
         self.module_config = self._get_module_config(config, module_name)
-        self.format_config = SimpleNamespace(module_name=module_name)
+        self.format_config = SimpleNamespace(
+            module_name=format_module_name or module_name
+        )
         self.logger = logger
         self.module_name = module_name
         self.SEND_HANDLERS = {
@@ -81,7 +93,26 @@ class NotificationManager:
             return resp.text
 
     @staticmethod
+    def resolve_color(
+        output: Any,
+        config_color: Optional[str],
+        default: Union[int, str] = 0x00FF00,
+    ) -> Union[int, str]:
+        """Output-supplied color (e.g. red for errors) wins, then user's UI color, then default."""
+        if isinstance(output, dict):
+            out_color = output.get("color")
+            if out_color is not None and out_color != "":
+                return out_color
+        if config_color:
+            return config_color
+        return default
+
+    @staticmethod
     def build_notifiarr_payload(module_title: str, cid: int) -> Dict[str, Any]:
+        # Notifiarr Passthrough has no documented field for overriding the
+        # Discord bot username — the bot identity is controlled by the user's
+        # Custom Bot setup on the Notifiarr side. CHUB's `bot_name` field is
+        # therefore a CHUB-side label only for the Notifiarr service.
         return {
             "notification": {"update": False, "name": module_title, "event": "0"},
             "discord": {
@@ -107,6 +138,7 @@ class NotificationManager:
         timestamp: str,
         dry_run: bool = False,
         color: Union[int, str] = 0x00FF00,
+        bot_name: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         if isinstance(color, str):
             color = int(color.lstrip("#"), 16)
@@ -141,7 +173,7 @@ class NotificationManager:
                 )
             elif dry_run:
                 payload["content"] = "__**Dry Run**__"
-            payload["username"] = "Notification Bot"
+            payload["username"] = bot_name or "Notification Bot"
             payloads.append(payload)
         return payloads
 
@@ -240,9 +272,7 @@ class NotificationManager:
                     "description": " ",
                     "content": content,
                 }
-            color = "00FF00"
-            if isinstance(output, dict):
-                color = output.get("color", "00FF00")
+            color = self.resolve_color(output, auth_data.color, default="00FF00")
             if isinstance(color, int):
                 color = f"{color:06X}"
             elif isinstance(color, str):
@@ -253,22 +283,41 @@ class NotificationManager:
 
     def send_discord_notification(
         self,
-        hook: str,
+        auth_data: DiscordConfig,
         module_title: str,
         output: Any,
+        test: bool = False,
     ) -> Tuple[bool, str]:
         from datetime import datetime
 
         from backend.util.notification_formatting import format_for_discord
 
-        data, _ = format_for_discord(self.format_config, output)
+        hook = auth_data.webhook.rstrip("/")
+        bot_name = auth_data.bot_name
         timestamp = datetime.utcnow().isoformat()
-        dry_run = getattr(self.module_config, "dry_run", False)
-        color = output.get("color", 0x00FF00) if isinstance(output, dict) else 0x00FF00
+        color = self.resolve_color(output, auth_data.color, default=0x00FF00)
+
+        if test:
+            data = [
+                {
+                    "embed": True,
+                    "fields": [
+                        {
+                            "name": "Test Notification",
+                            "value": "This is a test notification from CHUB.",
+                        }
+                    ],
+                }
+            ]
+            dry_run = False
+        else:
+            data, _ = format_for_discord(self.format_config, output)
+            dry_run = getattr(self.module_config, "dry_run", False)
+
         success = True
         messages = []
         for payload in self.build_discord_payload(
-            module_title, data, timestamp, dry_run=dry_run, color=color
+            module_title, data, timestamp, dry_run=dry_run, color=color, bot_name=bot_name
         ):
             ok, msg = self.send_and_log_response("Discord", hook, payload)
             if not ok:
@@ -344,26 +393,17 @@ class NotificationManager:
                     target_data[ttype] = f"Invalid config for {ttype}"
                     continue
                 if ttype == "discord":
-                    if test:
-                        hook = target.get("webhook", "").rstrip("/")
-                        parts = hook.rstrip("/").split("/")
-                        if len(parts) >= 7 and parts[4] == "webhooks":
-                            webhook_id = parts[5]
-                            token = parts[6]
-                            apprise_url = f"discord://{webhook_id}/{token}"
-                            target_data["discord"] = apprise_url
-                        else:
-                            msg = "Invalid Discord webhook URL"
-                            logger.warning(msg)
-                            target_data["discord"] = msg
+                    hook = target.get("webhook", "").rstrip("/")
+                    if hook:
+                        target_data[ttype] = {
+                            "webhook": hook,
+                            "bot_name": target.get("bot_name") or None,
+                            "color": target.get("color") or None,
+                        }
                     else:
-                        hook = target.get("webhook", "").rstrip("/")
-                        if hook:
-                            target_data[ttype] = hook
-                        else:
-                            msg = "Invalid Discord configuration"
-                            logger.warning(msg)
-                            target_data[ttype] = msg
+                        msg = "Invalid Discord configuration"
+                        logger.warning(msg)
+                        target_data[ttype] = msg
                 elif ttype == "notifiarr":
                     hook = target.get("webhook", "").rstrip("/")
                     cid = target.get("channel_id")
@@ -382,6 +422,8 @@ class NotificationManager:
                         target_data["notifiarr"] = {
                             "webhook": hook,
                             "channel_id": cid_int,
+                            "bot_name": target.get("bot_name") or None,
+                            "color": target.get("color") or None,
                         }
                     else:
                         logger.warning("Invalid Notifiarr configuration")
@@ -442,7 +484,8 @@ class NotificationManager:
                         cfg = NotifiarrConfig(**data)
                         ok, msg = handler(cfg, module_title, output)
                     elif target == "discord":
-                        ok, msg = handler(data, module_title, output)
+                        cfg = DiscordConfig(**data)
+                        ok, msg = handler(cfg, module_title, output)
                     elif target == "email":
                         apprise = Apprise()
                         apprise.add(data)
@@ -495,6 +538,11 @@ class NotificationManager:
                 if target == "notifiarr":
                     cfg = NotifiarrConfig(**data)
                     ok, msg = self.send_notifiarr_notification(
+                        cfg, module_title, None, test=True
+                    )
+                elif target == "discord":
+                    cfg = DiscordConfig(**data)
+                    ok, msg = self.send_discord_notification(
                         cfg, module_title, None, test=True
                     )
                 else:
@@ -571,13 +619,32 @@ class NotificationManager:
 
 
 class ErrorNotifyHandler(logging.Handler):
-    """Custom logging handler to send errors to Discord/Notifiarr via notifications."""
+    """Custom logging handler to send errors to Discord/Notifiarr/Email via notifications.
+
+    Reads the notification config from the `main` section but renders using the
+    `error_notify` formatter. Uses a thread-local re-entry guard so log calls made
+    by the notification machinery itself don't recursively trigger more notifications.
+    """
+
+    _reentry = threading.local()
 
     def __init__(self, config, module_name="main", logger=None):
         super().__init__(level=logging.ERROR)
-        self.manager = NotificationManager(config, logger, module_name)
+        self.manager = NotificationManager(
+            config, logger, module_name, format_module_name="error_notify"
+        )
 
     def emit(self, record):
+        if getattr(ErrorNotifyHandler._reentry, "active", False):
+            return
+        # The notification dispatch path itself logs at ERROR on failure; ignore
+        # records originating from it to avoid feedback loops independent of the
+        # thread-local guard (e.g. a different thread reading the same logger).
+        if record.name == "chub.notification" or "notification" in (
+            getattr(record, "module", "") or ""
+        ):
+            return
+        ErrorNotifyHandler._reentry.active = True
         try:
             msg = record.getMessage()
             tb = None
@@ -589,13 +656,8 @@ class ErrorNotifyHandler(logging.Handler):
                     error_type_msg = tb_lines[-1].strip()
             elif record.stack_info:
                 tb = record.stack_info
-            else:
-                tb = None
 
-            if error_type_msg:
-                error_msg = f"{msg}\n{error_type_msg}"
-            else:
-                error_msg = msg
+            error_msg = f"{msg}\n{error_type_msg}" if error_type_msg else msg
 
             output = {
                 "error_message": error_msg,
@@ -610,6 +672,37 @@ class ErrorNotifyHandler(logging.Handler):
                 self.manager.logger.error(
                     f"[ErrorNotifyHandler] Failed to send error notification: {e}"
                 )
+        finally:
+            ErrorNotifyHandler._reentry.active = False
+
+
+def install_error_notify_handler(config, logger=None) -> Optional[ErrorNotifyHandler]:
+    """Attach ErrorNotifyHandler to the root logger if notifications.main is configured.
+
+    Returns the handler instance (or None if not installed). Safe to call multiple
+    times — subsequent calls are no-ops once a handler is attached.
+    """
+    root = logging.getLogger()
+    for existing in root.handlers:
+        if isinstance(existing, ErrorNotifyHandler):
+            return existing
+
+    main_targets: Dict[str, Any] = {}
+    raw = getattr(config, "notifications", None)
+    if raw is not None:
+        if hasattr(raw, "model_dump"):
+            raw = raw.model_dump(mode="python")
+        if isinstance(raw, dict):
+            section = raw.get("main")
+            if isinstance(section, dict):
+                main_targets = section
+
+    if not any(k in main_targets for k in ("discord", "notifiarr", "email")):
+        return None
+
+    handler = ErrorNotifyHandler(config, module_name="main", logger=logger)
+    root.addHandler(handler)
+    return handler
 
 
 def get_random_joke() -> str:

--- a/backend/util/notification_formatting.py
+++ b/backend/util/notification_formatting.py
@@ -1378,6 +1378,41 @@ def format_for_email(config: Any, output: Any) -> Tuple[str, bool]:
         sections.append("</div>")
         return "".join(sections)
 
+    def fmt_version_check(output: dict) -> str:
+        """Format version_check output for email (HTML)."""
+        from html import escape
+
+        local_version = escape(str(output.get("local_version", "")))
+        remote_version = escape(str(output.get("remote_version", "")))
+        return (
+            "<div class='section'>"
+            "<h3>🚨 Update Available</h3>"
+            f"<p><strong>Your Version:</strong> {local_version}</p>"
+            f"<p><strong>Latest Version:</strong> {remote_version}</p>"
+            "</div>"
+        )
+
+    def fmt_error_notify(output: dict) -> str:
+        """Format error_notify output for email (HTML)."""
+        from html import escape
+
+        error_msg = escape(str(output.get("error_message", "")))
+        source_module = escape(str(output.get("source_module", "")))
+        tb = output.get("traceback")
+        sections = [
+            "<div class='section'>",
+            "<h3>⚠️ Error Notification</h3>",
+            f"<p><strong>Module:</strong> {source_module}</p>",
+            f"<p><strong>Error:</strong> {error_msg}</p>",
+        ]
+        if tb:
+            tb_str = str(tb)
+            if len(tb_str) > 4000:
+                tb_str = tb_str[:4000] + "\n...truncated..."
+            sections.append(f"<pre>{escape(tb_str)}</pre>")
+        sections.append("</div>")
+        return "".join(sections)
+
     registry: Dict[str, Any] = {
         "poster_renamerr": fmt_poster_renamerr,
         "renameinatorr": fmt_renameinatorr,
@@ -1392,6 +1427,8 @@ def format_for_email(config: Any, output: Any) -> Tuple[str, bool]:
         "plex_maintenance": fmt_plex_maintenance,
         "border_replacerr": fmt_border_replacerr,
         "sync_gdrive": fmt_sync_gdrive,
+        "version_check": fmt_version_check,
+        "error_notify": fmt_error_notify,
     }
     formatter = registry.get(config.module_name)
     if not formatter:

--- a/frontend/src/components/notifications/NotificationCard.jsx
+++ b/frontend/src/components/notifications/NotificationCard.jsx
@@ -55,7 +55,7 @@ export const NotificationCard = ({
                     <div className="text-tertiary">Bot: {config.bot_name || 'Not set'}</div>
                 )}
                 {serviceType === 'notifiarr' && (
-                    <div className="text-tertiary">Bot: {config.bot_name || 'Not set'}</div>
+                    <div className="text-tertiary">Channel: {config.channel_id || 'Not set'}</div>
                 )}
                 {serviceType === 'email' && (
                     <div className="text-tertiary">Server: {config.smtp_server || 'Not set'}</div>

--- a/frontend/src/utils/api/notifications.js
+++ b/frontend/src/utils/api/notifications.js
@@ -24,8 +24,8 @@ export const notificationsAPI = {
      * {
      *   module_name: {
      *     discord: { bot_name, color, webhook },
-     *     notifiarr: { bot_name, color, webhook, channel_id },
-     *     email: { smtp_server, smtp_port, use_tls, username, password, to, from }
+     *     notifiarr: { color, webhook, channel_id },
+     *     email: { smtp_server, smtp_port, use_tls, username, password, from, to }
      *   }
      * }
      */

--- a/frontend/src/utils/constants/notifications_schema.js
+++ b/frontend/src/utils/constants/notifications_schema.js
@@ -123,14 +123,14 @@ export const NOTIFICATIONS_SCHEMA = [
                 placeholder: '••••••••',
             },
             {
-                key: 'to',
+                key: 'from',
                 label: 'From',
                 type: 'text',
                 required: true,
                 placeholder: 'My App <bot@email.com>',
             },
             {
-                key: 'from',
+                key: 'to',
                 label: 'Recipients',
                 type: 'text',
                 required: true,

--- a/frontend/src/utils/constants/notifications_schema.js
+++ b/frontend/src/utils/constants/notifications_schema.js
@@ -64,13 +64,6 @@ export const NOTIFICATIONS_SCHEMA = [
         label: 'Notifiarr',
         fields: [
             {
-                key: 'bot_name',
-                label: 'Bot Name',
-                type: 'text',
-                required: true,
-                placeholder: 'My Notifiarr Bot',
-            },
-            {
                 key: 'color',
                 label: 'Embed Color',
                 type: 'color',

--- a/tests/test_jduparr.py
+++ b/tests/test_jduparr.py
@@ -221,9 +221,15 @@ def test_notification_manager_reads_jduparr_targets_from_full_config(monkeypatch
     )
     manager = NotificationManager(config, CapturingLogger(), module_name="jduparr")
 
+    from backend.util.notification import DiscordConfig
+
     assert manager.module_config.dry_run is True
     assert manager.collect_valid_targets() == {
-        "discord": "https://discord.com/api/webhooks/1/token"
+        "discord": {
+            "webhook": "https://discord.com/api/webhooks/1/token",
+            "bot_name": None,
+            "color": None,
+        }
     }
 
     monkeypatch.setattr(
@@ -232,7 +238,7 @@ def test_notification_manager_reads_jduparr_targets_from_full_config(monkeypatch
         lambda _label, _hook, _payload: (True, "ok"),
     )
     ok, message = manager.send_discord_notification(
-        "https://discord.com/api/webhooks/1/token",
+        DiscordConfig(webhook="https://discord.com/api/webhooks/1/token"),
         "Jduparr",
         [
             {

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -217,18 +217,19 @@ def test_collect_targets_discord_test_path_returns_same_shape_as_prod():
     assert prod["discord"]["webhook"] == test["discord"]["webhook"]
 
 
-def test_collect_targets_notifiarr_preserves_bot_name_and_color():
+def test_collect_targets_notifiarr_preserves_color_and_channel():
     cfg = _cfg_with_notifiarr(
         webhook="https://notifiarr.com/api/v1/notification/passthrough/KEY",
         channel_id="1234567890",
-        bot_name="My Notifiarr Bot",
         color="#FF7300",
     )
     m = make_manager(cfg)
     targets = m.collect_valid_targets()
     assert targets["notifiarr"]["channel_id"] == 1234567890
-    assert targets["notifiarr"]["bot_name"] == "My Notifiarr Bot"
     assert targets["notifiarr"]["color"] == "#FF7300"
+    # Notifiarr has no per-notification bot override, so we don't carry bot_name
+    # through (the UI form doesn't accept it either).
+    assert "bot_name" not in targets["notifiarr"]
 
 
 def test_collect_targets_email_maps_from_and_to_correctly():
@@ -334,7 +335,6 @@ def test_send_notifiarr_test_posts_passthrough_payload_to_webhook():
     cfg = NotifiarrConfig(
         webhook="https://notifiarr.com/api/v1/notification/passthrough/KEY",
         channel_id=42,
-        bot_name="NotifBot",  # CHUB-side label; not sent in payload (see comment above)
     )
     with patch.object(NotificationManager, "safe_post") as post:
         post.return_value = SimpleNamespace(status_code=200, text="")

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,10 +1,18 @@
 """Tests for backend/util/notification.py — payload formatting helpers."""
 
+import logging
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
-from backend.util.notification import NotificationManager, get_random_joke
+from backend.util.notification import (
+    DiscordConfig,
+    ErrorNotifyHandler,
+    NotifiarrConfig,
+    NotificationManager,
+    get_random_joke,
+    install_error_notify_handler,
+)
 
 
 def make_manager(config=None):
@@ -145,3 +153,231 @@ def test_notification_targets_empty_when_no_match():
     cfg = SimpleNamespace(notifications={"other_module": {"discord": {}}})
     m = make_manager(cfg)
     assert m._get_notification_targets() == {}
+
+
+# --- resolve_color: output > config > default ---
+
+
+def test_resolve_color_output_wins():
+    assert (
+        NotificationManager.resolve_color({"color": "FF0000"}, "00FF00")
+        == "FF0000"
+    )
+
+
+def test_resolve_color_falls_back_to_config():
+    assert NotificationManager.resolve_color({}, "FF7300") == "FF7300"
+
+
+def test_resolve_color_default_when_neither_set():
+    assert NotificationManager.resolve_color({}, None) == 0x00FF00
+
+
+def test_resolve_color_empty_output_color_does_not_override():
+    """An empty-string color in output (legacy default) shouldn't beat config."""
+    assert NotificationManager.resolve_color({"color": ""}, "FF7300") == "FF7300"
+
+
+# --- collect_valid_targets: bot_name + color survive into the dispatch dict ---
+
+
+def _cfg_with_discord(**discord_fields):
+    return SimpleNamespace(
+        notifications={"poster_renamerr": {"discord": discord_fields}}
+    )
+
+
+def _cfg_with_notifiarr(**fields):
+    return SimpleNamespace(
+        notifications={"poster_renamerr": {"notifiarr": fields}}
+    )
+
+
+def test_collect_targets_discord_preserves_bot_name_and_color():
+    cfg = _cfg_with_discord(
+        webhook="https://discord.com/api/webhooks/123/abc",
+        bot_name="My Bot",
+        color="#5865F2",
+    )
+    m = make_manager(cfg)
+    targets = m.collect_valid_targets()
+    assert targets["discord"]["webhook"] == "https://discord.com/api/webhooks/123/abc"
+    assert targets["discord"]["bot_name"] == "My Bot"
+    assert targets["discord"]["color"] == "#5865F2"
+
+
+def test_collect_targets_discord_test_path_returns_same_shape_as_prod():
+    """Regression: test mode used to convert webhook → apprise URL string, diverging from prod."""
+    cfg = _cfg_with_discord(webhook="https://discord.com/api/webhooks/123/abc")
+    m = make_manager(cfg)
+    prod = m.collect_valid_targets(test=False)
+    test = m.collect_valid_targets(test=True)
+    assert isinstance(prod["discord"], dict)
+    assert isinstance(test["discord"], dict)
+    assert prod["discord"]["webhook"] == test["discord"]["webhook"]
+
+
+def test_collect_targets_notifiarr_preserves_bot_name_and_color():
+    cfg = _cfg_with_notifiarr(
+        webhook="https://notifiarr.com/api/v1/notification/passthrough/KEY",
+        channel_id="1234567890",
+        bot_name="My Notifiarr Bot",
+        color="#FF7300",
+    )
+    m = make_manager(cfg)
+    targets = m.collect_valid_targets()
+    assert targets["notifiarr"]["channel_id"] == 1234567890
+    assert targets["notifiarr"]["bot_name"] == "My Notifiarr Bot"
+    assert targets["notifiarr"]["color"] == "#FF7300"
+
+
+def test_collect_targets_email_maps_from_and_to_correctly():
+    """Regression: UI label/key swap used to invert sender/recipients."""
+    cfg = SimpleNamespace(
+        notifications={
+            "poster_renamerr": {
+                "email": {
+                    "smtp_server": "smtp.example.com",
+                    "smtp_port": 587,
+                    "use_tls": True,
+                    "username": "user",
+                    "password": "pw",
+                    "from": "sender@example.com",
+                    "to": "recipient@example.com",
+                }
+            }
+        }
+    )
+    m = make_manager(cfg)
+    url = m.collect_valid_targets()["email"]
+    # Apprise mailto URL must have to=recipient, from=sender
+    assert "to=recipient%40example.com" in url
+    assert "from=sender%40example.com" in url
+    assert url.startswith("mailtos://")  # use_tls=True
+
+
+# --- build_discord_payload: bot_name reaches the Discord username field ---
+
+
+def test_build_discord_payload_uses_bot_name():
+    payloads = NotificationManager.build_discord_payload(
+        "Mod",
+        [{"embed": True, "fields": []}],
+        "2024-01-01T00:00:00Z",
+        bot_name="Cool Bot",
+    )
+    assert payloads[0]["username"] == "Cool Bot"
+
+
+def test_build_discord_payload_falls_back_to_default_username():
+    payloads = NotificationManager.build_discord_payload(
+        "Mod",
+        [{"embed": True, "fields": []}],
+        "2024-01-01T00:00:00Z",
+    )
+    assert payloads[0]["username"] == "Notification Bot"
+
+
+# --- build_notifiarr_payload: no bot override (Notifiarr Passthrough doesn't expose one) ---
+
+
+def test_build_notifiarr_payload_has_no_bot_block():
+    """Notifiarr Passthrough has no documented field for overriding the Discord
+    bot username — it's controlled by the user's Custom Bot setup on Notifiarr's
+    side. Make sure we don't ship a bogus key Notifiarr will silently ignore."""
+    p = NotificationManager.build_notifiarr_payload("T", 1)
+    assert "bot" not in p["discord"]
+
+
+# --- End-to-end send_discord_notification (test=True path uses raw POST) ---
+
+
+def test_send_discord_test_uses_raw_post_with_bot_name_and_color():
+    m = make_manager()
+    cfg = DiscordConfig(
+        webhook="https://discord.com/api/webhooks/1/tok",
+        bot_name="TestBot",
+        color="#123456",
+    )
+    with patch.object(NotificationManager, "safe_post") as post:
+        post.return_value = SimpleNamespace(status_code=204, text="")
+        ok, _ = m.send_discord_notification(cfg, "Mod", None, test=True)
+    assert ok
+    post.assert_called_once()
+    sent_url, sent_payload = post.call_args.args
+    assert sent_url == "https://discord.com/api/webhooks/1/tok"
+    assert sent_payload["username"] == "TestBot"
+    assert sent_payload["embeds"][0]["color"] == 0x123456
+
+
+def test_send_discord_prod_uses_config_color_then_output_override():
+    """Output color (e.g. red for errors) must beat config color."""
+    m = make_manager()
+    cfg = DiscordConfig(
+        webhook="https://discord.com/api/webhooks/1/tok",
+        color="00FF00",
+    )
+    with patch.object(NotificationManager, "safe_post") as post, patch(
+        "backend.util.notification_formatting.format_for_discord",
+        return_value=([{"embed": True, "fields": []}], True),
+    ):
+        post.return_value = SimpleNamespace(status_code=204, text="")
+        m.send_discord_notification(cfg, "Mod", {"color": "FF0000"})
+    assert post.call_args.args[1]["embeds"][0]["color"] == 0xFF0000
+
+
+# --- End-to-end send_notifiarr_notification ---
+
+
+def test_send_notifiarr_test_posts_passthrough_payload_to_webhook():
+    m = make_manager()
+    cfg = NotifiarrConfig(
+        webhook="https://notifiarr.com/api/v1/notification/passthrough/KEY",
+        channel_id=42,
+        bot_name="NotifBot",  # CHUB-side label; not sent in payload (see comment above)
+    )
+    with patch.object(NotificationManager, "safe_post") as post:
+        post.return_value = SimpleNamespace(status_code=200, text="")
+        ok, _ = m.send_notifiarr_notification(cfg, "Mod", None, test=True)
+    assert ok
+    sent_url, sent_payload = post.call_args.args
+    assert sent_url == "https://notifiarr.com/api/v1/notification/passthrough/KEY"
+    assert sent_payload["discord"]["ids"]["channel"] == 42
+    assert sent_payload["notification"]["name"] == "Mod"
+
+
+# --- install_error_notify_handler ---
+
+
+def teardown_function(_):
+    """Strip any ErrorNotifyHandler the tests installed on the root logger."""
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        if isinstance(h, ErrorNotifyHandler):
+            root.removeHandler(h)
+
+
+def test_install_error_notify_handler_noop_without_main_target():
+    cfg = SimpleNamespace(notifications={})
+    assert install_error_notify_handler(cfg) is None
+    assert not any(
+        isinstance(h, ErrorNotifyHandler) for h in logging.getLogger().handlers
+    )
+
+
+def test_install_error_notify_handler_attaches_when_main_configured():
+    cfg = SimpleNamespace(
+        notifications={"main": {"discord": {"webhook": "https://discord.com/api/webhooks/1/t"}}}
+    )
+    handler = install_error_notify_handler(cfg)
+    assert isinstance(handler, ErrorNotifyHandler)
+    assert handler in logging.getLogger().handlers
+
+
+def test_install_error_notify_handler_idempotent():
+    cfg = SimpleNamespace(
+        notifications={"main": {"discord": {"webhook": "https://discord.com/api/webhooks/1/t"}}}
+    )
+    h1 = install_error_notify_handler(cfg)
+    h2 = install_error_notify_handler(cfg)
+    assert h1 is h2


### PR DESCRIPTION
## Summary

Closes six gaps the notifications system had between what the UI promised and what reached the user. Found by walking the full pipeline (UI form → API persistence → `collect_valid_targets` → send handlers → wire payload) for all three services.

### Discord webhook
- **Bot Name** now sets `payload.username` (was hard-coded to "Notification Bot").
- **Embed Color** from the UI now reaches the embed sidebar (was silently dropped; output color still wins for errors via new `resolve_color()` helper).
- **Test button** now POSTs directly to the webhook — same path as production. Previously the test went through Apprise's `discord://` URL while production used raw POST, so a green test didn't actually prove production worked.

### Notifiarr Passthrough
- **Embed Color** from the UI now reaches `discord.color` (was dropped).
- **Bot Name** is kept as a CHUB-side label — verified against [Notifiarr's Passthrough docs](https://notifiarr.wiki/pages/integrations/passthrough/) that the API has no per-notification bot override (bot identity is configured via Notifiarr's Custom Bot setup). Documented this in the wiki.

### Email (SMTP)
- Frontend schema had `key`/`label` swapped for the From / Recipients fields, so configs saved via the UI had sender and recipients inverted. Fixed the keys to match the backend (`from` = sender, `to` = recipients).
- Added missing email formatters for `version_check` and `error_notify` (they had Discord formatters only, so email sends silently no-op'd).

### Catch-all errors (`notifications.main`)
- `ErrorNotifyHandler` is now actually attached to the root logger on FastAPI startup. Previously the class existed but was never instantiated — the `main` notification target was documented but did nothing.
- Re-entry guarded (thread-local + name-based record filter) to prevent feedback loops if the notification dispatch itself logs at ERROR.

### Tests
- 18 new tests in `test_notification.py` covering color precedence, the wired-through fields, the unified Discord test path, the email from/to mapping, and `install_error_notify_handler` idempotency. Full suite: 505 passing.

## Test plan

- [ ] Pull the branch, configure a Discord webhook notification via the UI, hit Test — embed shows up in the target channel with the configured Bot Name and Color.
- [ ] Same for Notifiarr (Bot Name will not change the Discord username — that's a Notifiarr-side limitation, now documented in the wiki).
- [ ] Configure an email notification via the UI, hit Test — sender and recipients are no longer swapped.
- [ ] Configure `notifications.main` with any service and trigger an ERROR-level log — verify the catch-all routes it.
- [ ] `pytest` clean (505 pass on my machine).