### PR TITLE
fix(plex): year-disambiguate title matches; log 401 request path

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -74,6 +74,20 @@ class AuthMiddleware(BaseHTTPMiddleware):
     so the setup flow can proceed.
     """
 
+    @staticmethod
+    def _log_unauthorized(request: Request, reason: str, path: str) -> None:
+        """Warn (with the request path) on a rejected API call so 401s are
+        diagnosable in the logs. Best-effort: a logging failure must never
+        affect the auth response itself."""
+        try:
+            logger = getattr(request.app.state, "logger", None)
+            if logger is not None:
+                logger.get_adapter("API").warning(
+                    f"Unauthorized API request – {reason} ({path})"
+                )
+        except Exception:
+            pass
+
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
 
@@ -107,6 +121,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             token = request.query_params.get("token", "")
 
         if not token:
+            self._log_unauthorized(request, "missing Bearer token", path)
             return JSONResponse(
                 status_code=401,
                 content={
@@ -117,6 +132,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             )
         payload = decode_access_token(token, config.auth.jwt_secret)
         if payload is None:
+            self._log_unauthorized(request, "invalid or expired token", path)
             return JSONResponse(
                 status_code=401,
                 content={

--- a/backend/util/plex_index.py
+++ b/backend/util/plex_index.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional, Tuple
 
+from backend.util.helper import YEAR_MATCH_TOLERANCE
 from backend.util.normalization import normalize_titles
 
 # Priority order of match keys per media type (highest-confidence first). Guids
@@ -32,6 +33,18 @@ MOVIE_PRIORITY_KEYS = ["tmdb", "imdb", "title"]
 SHOW_PRIORITY_KEYS = ["tvdb", "tmdb", "imdb", "title"]
 SEASON_PRIORITY_KEYS = ["tvdb", "tmdb", "imdb", "title"]
 COLLECTION_PRIORITY_KEYS = ["title"]
+
+
+def _coerce_year(value: Any) -> Optional[int]:
+    """Best-effort int year from a cache/asset field that may be int, the TEXT
+    "2007", or an empty/None/"None" placeholder. Returns None when absent or
+    unparseable so callers can treat "no year" as "can't disambiguate"."""
+    if value in (None, "", "None", "null"):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _coerce_guids(value: Any) -> Dict[str, Any]:
@@ -116,31 +129,81 @@ class PlexMediaIndex:
     # ----- lookup ---------------------------------------------------------
 
     @staticmethod
+    def _disambiguate_by_year(
+        entries: List[Dict], asset_year: Optional[int]
+    ) -> List[Dict]:
+        """Drop same-title collisions of the clearly-wrong year.
+
+        A title-only match can return more than one item that shares a
+        normalized title but is a different release (e.g. "3:10 to Yuma" 1957
+        vs 2007). Without the year we'd hand back every copy and the caller
+        could upload the wrong-year poster — or, when only the wrong-year item
+        is in Plex, upload to it because Plex hasn't scanned ours yet.
+
+        A candidate is dropped ONLY when both it and the asset carry a year and
+        they differ by more than ``YEAR_MATCH_TOLERANCE`` (Plex's year can lag
+        *arr/TMDB by a year — production vs release — so the same ±1 tolerance
+        the live search uses applies here). Candidates with no year are kept, so
+        a metadata gap can never cause a false skip. When nothing is dropped the
+        original list is returned unchanged; when a wrong-year copy IS dropped
+        the (possibly empty) survivors are returned — an empty result means the
+        caller should treat it as a miss rather than match the wrong year.
+        """
+        target = _coerce_year(asset_year)
+        if target is None:
+            return entries
+        kept: List[Dict] = []
+        dropped_wrong_year = False
+        for e in entries:
+            ey = _coerce_year(e.get("year"))
+            if ey is None or abs(ey - target) <= YEAR_MATCH_TOLERANCE:
+                kept.append(e)
+            else:
+                dropped_wrong_year = True
+        return kept if dropped_wrong_year else entries
+
+    @staticmethod
     def _match(
         index: Dict[str, List[Dict]], priority_keys: List[str], values: Dict[str, Any]
     ) -> Tuple[List[Dict], Optional[str]]:
         """Return (entries, matched_key_name) for the first priority key that
-        hits, or ([], None). Entries is the list of every library copy."""
+        hits, or ([], None). Entries is the list of every library copy.
+
+        Guid hits (tmdb/imdb/tvdb) are exact and returned as-is. A TITLE hit is
+        year-disambiguated against ``values['year']`` so a same-title/different-
+        year collision can't return the wrong release; if that leaves no
+        year-correct copy the title key is treated as a miss (([], None))."""
         for key in priority_keys:
             value = values.get(key)
             if value and f"{key}:{value}" in index:
-                return index[f"{key}:{value}"], key.upper()
+                entries = index[f"{key}:{value}"]
+                if key == "title":
+                    entries = PlexMediaIndex._disambiguate_by_year(
+                        entries, values.get("year")
+                    )
+                    if not entries:
+                        return [], None
+                return entries, key.upper()
         return [], None
 
     @staticmethod
     def _search_values(
         asset: Dict, *, season_number: Optional[int] = None,
         title_override: Optional[str] = None,
-    ) -> Dict[str, Optional[str]]:
+    ) -> Dict[str, Any]:
         """Build the guid/title lookup values from a media/asset row. Season
         rows suffix EVERY key with ":S{n}" so guid keys match the season index
         (a bare guid would collide across a show's seasons)."""
         title = asset.get("title", "")
-        values: Dict[str, Optional[str]] = {
+        values: Dict[str, Any] = {
             "tmdb": str(asset.get("tmdb_id")) if asset.get("tmdb_id") else None,
             "imdb": asset.get("imdb_id"),
             "tvdb": str(asset.get("tvdb_id")) if asset.get("tvdb_id") else None,
             "title": title_override or (normalize_titles(title) if title else None),
+            # Carried for title-match year-disambiguation (see _match). Inert for
+            # guid hits; None when the row has no year, which keeps current
+            # behavior.
+            "year": _coerce_year(asset.get("year")),
         }
         if season_number is not None:
             for k in ("tmdb", "imdb", "tvdb"):

--- a/backend/util/upload_posters.py
+++ b/backend/util/upload_posters.py
@@ -552,6 +552,10 @@ class PosterUploader:
                 "imdb": asset.get("imdb_id"),
                 "tvdb": str(asset.get("tvdb_id")) if asset.get("tvdb_id") else None,
                 "title": title_override or normalize_titles(asset_title),
+                # Year-disambiguates title-only matches so a same-title/different-
+                # year collision can't upload the wrong release (see
+                # PlexMediaIndex._match). Inert for guid hits.
+                "year": asset.get("year"),
             }
 
             # Season entries are indexed with a ":S{n}" suffix on EVERY key


### PR DESCRIPTION
Ports two fixes observed in the sibling **posterflow** project (v0.7.5, commits June 5–7) into CHUB.

## 1. Year-disambiguate Plex title matches (correctness)
`PlexMediaIndex` matched assets on a **year-stripped** title key, so same-title/different-year releases (e.g. *3:10 to Yuma* 1957 vs 2007) collided on one key and every copy was returned. Result: the wrong-year poster could be uploaded, and when only the wrong-year item was in Plex (ours not yet scanned) it was matched anyway.

Title-key hits are now year-disambiguated against the asset's year:
- A candidate is dropped **only** when both it and the asset carry a year and they differ by more than `YEAR_MATCH_TOLERANCE` (the same ±1 tolerance the live search already uses, for production-vs-release drift).
- Candidates with no year are kept → a metadata gap never causes a false skip.
- When no year-correct copy remains, the title key is treated as a **miss** rather than matching the wrong release.
- Guid hits (tmdb/imdb/tvdb) stay exact and are **never** year-filtered.

Covers both consumers — `asset_renamerr`'s `resolve()` and `upload_posters`' `match_asset()`.

## 2. Log request path on unauthorized 401s (diagnostics)
`AuthMiddleware` returned 401 with no log line. Added a best-effort warning recording the path and reason (missing vs invalid token); a logging failure can never affect the 401 response.

## Testing
- `ruff` clean on all three files.
- `pytest` — `test_upload_posters`, `test_auth`, `test_tmdb_match_quality` pass.
- Direct behavioral test of the year logic: right-year wins, ±1 tolerance respected, wrong-year refused (incl. when only the wrong-year item exists in Plex), missing-year never skips, guid hits ignore year.
