### PR TITLE
feat(border): full-library re-border on renamerr run

### DIFF
--- a/backend/modules/border_replacerr.py
+++ b/backend/modules/border_replacerr.py
@@ -391,6 +391,17 @@ class BorderReplacerr(ChubModule):
             assets.append(row)
         return assets
 
+    @staticmethod
+    def _should_process_all(manifest, process_all: bool, reset_all: bool) -> bool:
+        """Decide whether to border the full matched library vs only the
+        manifest subset.
+
+        Full library when: the caller asked (process_all, e.g. a renamerr
+        full run), or the holiday state just changed (reset_all), or no
+        manifest was supplied (standalone module run). Otherwise the
+        manifest subset (webhook/adhoc imports)."""
+        return bool(process_all or reset_all or manifest is None)
+
     def run(self, manifest: dict):
         with ChubDB(logger=self.logger) as db:
             if self.config.log_level.lower() == "debug":

--- a/backend/modules/border_replacerr.py
+++ b/backend/modules/border_replacerr.py
@@ -349,6 +349,45 @@ class BorderReplacerr(ChubModule):
             )
             return None  # None = failure (vs False = no change needed)
 
+    def _asset_excluded(self, asset: dict) -> bool:
+        """True if this asset should be skipped per exclusion_list /
+        ignore_folders. Logs a debug line so the user can see why."""
+        title = asset.get("title")
+        if self.config.exclusion_list and title in self.config.exclusion_list:
+            self.logger.debug(f"Skipping '{title}' (in exclusion_list).")
+            return True
+        if (
+            self.config.ignore_folders
+            and asset.get("folder") in self.config.ignore_folders
+        ):
+            self.logger.debug(f"Skipping '{title}' (folder in ignore_folders).")
+            return True
+        return False
+
+    def _collect_matched_assets(self, db) -> list:
+        """Return every matched media row + matched collection row, with
+        exclusion_list / ignore_folders applied.
+
+        Unlike poster_renamerr.get_matched_assets(), this does NOT drop
+        already-moved posters (those whose renamed_file exists on disk), so
+        the full-library border pass re-borders the whole library, not just
+        the not-yet-moved subset carried in a manifest. Collections are
+        included here (the old reset_all branch processed media only)."""
+        assets: list = []
+        for row in db.media.get_all():
+            if row.get("matched") != 1:
+                continue
+            if self._asset_excluded(row):
+                continue
+            assets.append(row)
+        for row in db.collection.get_all():
+            if row.get("matched") != 1:
+                continue
+            if self._asset_excluded(row):
+                continue
+            assets.append(row)
+        return assets
+
     def run(self, manifest: dict):
         with ChubDB(logger=self.logger) as db:
             if self.config.log_level.lower() == "debug":

--- a/backend/modules/border_replacerr.py
+++ b/backend/modules/border_replacerr.py
@@ -374,6 +374,9 @@ class BorderReplacerr(ChubModule):
         the not-yet-moved subset carried in a manifest. Collections are
         included here (the old reset_all branch processed media only)."""
         assets: list = []
+        # Use .get() defensively: db rows are trusted but may be partial in
+        # edge cases (e.g. a row mid-write); a missing key skips the row rather
+        # than crashing the whole library pass.
         for row in db.media.get_all():
             if row.get("matched") != 1:
                 continue

--- a/backend/modules/border_replacerr.py
+++ b/backend/modules/border_replacerr.py
@@ -402,7 +402,7 @@ class BorderReplacerr(ChubModule):
         manifest subset (webhook/adhoc imports)."""
         return bool(process_all or reset_all or manifest is None)
 
-    def run(self, manifest: dict):
+    def run(self, manifest: Optional[dict] = None, process_all: bool = False):
         with ChubDB(logger=self.logger) as db:
             if self.config.log_level.lower() == "debug":
                 print_settings(self.logger, self.config)
@@ -430,31 +430,12 @@ class BorderReplacerr(ChubModule):
             skipped = 0
             failed = 0
             gate_skipped = 0
-            if reset_all:
+            if self._should_process_all(manifest, process_all, reset_all):
                 self.logger.debug(
-                    "Holiday state changed (or startup). Doing full reprocessing of all matched assets."
+                    "Full-library border pass: reprocessing all matched media "
+                    "and collections (includes already-moved posters)."
                 )
-                for row in db.media.get_all():
-                    if row["matched"] == 1:
-                        if (
-                            self.config.exclusion_list
-                            and row["title"] in self.config.exclusion_list
-                        ):
-                            self.logger.debug(
-                                f"Skipping '{row['title']}' (in exclusion_list)."
-                            )
-                            skipped += 1
-                            continue
-                        if (
-                            self.config.ignore_folders
-                            and row.get("folder") in self.config.ignore_folders
-                        ):
-                            self.logger.debug(
-                                f"Skipping '{row['title']}' (folder in ignore_folders)."
-                            )
-                            skipped += 1
-                            continue
-                        assets.append(row)
+                assets = self._collect_matched_assets(db)
             else:
                 all_ids = [("media_cache", i) for i in manifest["media_cache"]] + [
                     ("collections_cache", i) for i in manifest["collections_cache"]

--- a/backend/modules/border_replacerr.py
+++ b/backend/modules/border_replacerr.py
@@ -535,6 +535,17 @@ class BorderReplacerr(ChubModule):
                     )
                     skipped += 1
                     continue
+                if not os.path.exists(asset["original_file"]):
+                    # Full-library sweeps re-encounter posters whose source was
+                    # since removed (gdrive cleanup, one-time drops). Skip them
+                    # quietly instead of letting the encoder fail and tallying a
+                    # scary 'failed' every run.
+                    self.logger.debug(
+                        f"Skipping '{asset.get('title')}' — source poster missing "
+                        f"on disk ({asset['original_file']})."
+                    )
+                    skipped += 1
+                    continue
                 if border_paths:
                     variant = border_paths[variant_index % len(border_paths)]
                 elif border_colors:

--- a/backend/modules/poster_renamerr.py
+++ b/backend/modules/poster_renamerr.py
@@ -1197,15 +1197,22 @@ class PosterRenamerr(ChubModule):
         """
         return [self.config.destination_dir] if self.config.destination_dir else []
 
-    def run_border_replacerr(self, manifest: dict, progress_window=None, process_all=False):
+    def run_border_replacerr(self, manifest: Optional[dict], progress_window=None, process_all=False):
         from backend.modules.border_replacerr import BorderReplacerr
 
-        self.logger.debug(
-            "\nRunning border replacerr:\n"
-            f"  Media assets to process: {len(manifest.get('media_cache', []))}\n"
-            f"  Collection assets to process: {len(manifest.get('collections_cache', []))}\n"
-            f"  Total assets to process: {len(manifest.get('media_cache', [])) + len(manifest.get('collections_cache', []))}\n"
-        )
+        if process_all:
+            self.logger.debug(
+                "\nRunning border replacerr (full-library pass — re-bordering "
+                "all matched media and collections, including already-moved "
+                "posters; manifest counts are not representative).\n"
+            )
+        else:
+            self.logger.debug(
+                "\nRunning border replacerr:\n"
+                f"  Media assets to process: {len(manifest.get('media_cache', []))}\n"
+                f"  Collection assets to process: {len(manifest.get('collections_cache', []))}\n"
+                f"  Total assets to process: {len(manifest.get('media_cache', [])) + len(manifest.get('collections_cache', []))}\n"
+            )
 
         border = BorderReplacerr(logger=self.logger)
         # Drive the parent bar's reserved slice as posters complete.

--- a/backend/modules/poster_renamerr.py
+++ b/backend/modules/poster_renamerr.py
@@ -1197,7 +1197,7 @@ class PosterRenamerr(ChubModule):
         """
         return [self.config.destination_dir] if self.config.destination_dir else []
 
-    def run_border_replacerr(self, manifest: dict, progress_window=None):
+    def run_border_replacerr(self, manifest: dict, progress_window=None, process_all=False):
         from backend.modules.border_replacerr import BorderReplacerr
 
         self.logger.debug(
@@ -1214,7 +1214,7 @@ class PosterRenamerr(ChubModule):
                 getattr(self, "_job_id", None), getattr(self, "_job_db", None)
             )
             border.set_progress_window(*progress_window)
-        border.run(manifest)
+        border.run(manifest, process_all=process_all)
 
         self.logger.info("Finished running border_replacerr.")
 
@@ -1488,7 +1488,9 @@ class PosterRenamerr(ChubModule):
                 if self.config.run_border_replacerr:
                     with self._phase("border_replacerr"):
                         self.run_border_replacerr(
-                            manifest, progress_window=tail_windows.get("border")
+                            manifest,
+                            progress_window=tail_windows.get("border"),
+                            process_all=True,
                         )
 
                 # Strict either/or: upload to Plex only on the "plex" path. The

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -334,3 +334,95 @@ def test_renamerr_run_border_replacerr_forwards_process_all(monkeypatch):
 
     assert captured["process_all"] is True
     assert captured["manifest"] == manifest
+
+
+# ---- end-to-end: full pass borders all, second pass re-encodes nothing -----
+
+
+def test_full_pass_borders_all_then_skips_unchanged(tmp_path, monkeypatch):
+    import backend.modules.border_replacerr as border_mod
+    from backend.util.database.border_state import BorderState
+
+    # Real source posters on disk (1000x1500 so border ops are cheap/no-resize).
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+
+    rows = []
+    for name in ("alpha", "beta"):
+        src = src_dir / f"{name}.jpg"
+        Image.new("RGB", (1000, 1500), (10, 20, 30)).save(src, "JPEG")
+        rows.append(
+            {
+                "title": name,
+                "folder": name,
+                "matched": 1,
+                "original_file": str(src),
+                "renamed_file": str(dest_dir / f"{name}.jpg"),
+            }
+        )
+
+    border_state = BorderState(logger=StubLogger(), db_path=str(tmp_path / "b.db"))
+
+    class _FakeDB:
+        def __init__(self):
+            self.media = _StubTable(rows)
+            self.collection = _StubTable([])
+            self.holiday = SimpleNamespace(
+                get_status=lambda: {"last_active_holiday": None},
+                set_status=lambda *a, **k: None,
+            )
+            self.border = border_state
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(border_mod, "ChubDB", lambda *a, **k: _FakeDB())
+    # Notifications are irrelevant here; stub them so the run never touches one.
+    monkeypatch.setattr(
+        border_mod,
+        "NotificationManager",
+        lambda *a, **k: SimpleNamespace(send_notification=lambda *a, **k: None),
+    )
+
+    br = _make_br()
+    br.full_config = SimpleNamespace()
+    br.config = SimpleNamespace(
+        log_level="info",
+        holidays=[],
+        border_colors=["#FF0000"],  # color mode
+        skip=False,
+        exclusion_list=[],
+        ignore_folders=[],
+        dry_run=False,
+        border_width=26,
+        border_workers=1,  # deterministic, single-threaded
+    )
+
+    # Count actual border encodes so we can prove the gate skips the 2nd pass.
+    real_replace = BorderReplacerr.replace_borders.__get__(br, BorderReplacerr)
+    calls = {"n": 0}
+
+    def _counting_replace(*a, **k):
+        calls["n"] += 1
+        return real_replace(*a, **k)
+
+    br.replace_borders = _counting_replace
+
+    # First full pass: every asset is bordered and written.
+    br.run(process_all=True)
+    assert calls["n"] == 2
+    dest_alpha = dest_dir / "alpha.jpg"
+    dest_beta = dest_dir / "beta.jpg"
+    assert dest_alpha.exists() and dest_beta.exists()
+    first_bytes = (dest_alpha.read_bytes(), dest_beta.read_bytes())
+
+    # Second identical full pass: gate skips both -> no re-encode, no rewrite.
+    calls["n"] = 0
+    br.run(process_all=True)
+    assert calls["n"] == 0  # the skip-gate prevented any encode
+    assert (dest_alpha.read_bytes(), dest_beta.read_bytes()) == first_bytes

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -426,3 +426,159 @@ def test_full_pass_borders_all_then_skips_unchanged(tmp_path, monkeypatch):
     br.run(process_all=True)
     assert calls["n"] == 0  # the skip-gate prevented any encode
     assert (dest_alpha.read_bytes(), dest_beta.read_bytes()) == first_bytes
+
+
+def test_full_pass_skips_poster_with_missing_source(tmp_path, monkeypatch):
+    """A matched poster whose source file is gone from disk must be counted
+    as 'skipped' (no encode attempt, no dest written), not run through the
+    encoder and tallied as 'failed'."""
+    import backend.modules.border_replacerr as border_mod
+    from backend.util.database.border_state import BorderState
+
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+    row = {
+        "title": "ghost",
+        "folder": "ghost",
+        "matched": 1,
+        "original_file": str(tmp_path / "src" / "ghost.jpg"),  # never created
+        "renamed_file": str(dest_dir / "ghost.jpg"),
+    }
+    border_state = BorderState(logger=StubLogger(), db_path=str(tmp_path / "b.db"))
+
+    class _FakeDB:
+        def __init__(self):
+            self.media = _StubTable([row])
+            self.collection = _StubTable([])
+            self.holiday = SimpleNamespace(
+                get_status=lambda: {"last_active_holiday": None},
+                set_status=lambda *a, **k: None,
+            )
+            self.border = border_state
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(border_mod, "ChubDB", lambda *a, **k: _FakeDB())
+    monkeypatch.setattr(
+        border_mod,
+        "NotificationManager",
+        lambda *a, **k: SimpleNamespace(send_notification=lambda *a, **k: None),
+    )
+
+    br = _make_br()
+    br.full_config = SimpleNamespace()
+    br.config = SimpleNamespace(
+        log_level="info",
+        holidays=[],
+        border_colors=["#FF0000"],
+        skip=False,
+        exclusion_list=[],
+        ignore_folders=[],
+        dry_run=False,
+        border_width=26,
+        border_workers=1,
+    )
+
+    calls = {"n": 0}
+    real_replace = BorderReplacerr.replace_borders.__get__(br, BorderReplacerr)
+
+    def _counting(*a, **k):
+        calls["n"] += 1
+        return real_replace(*a, **k)
+
+    br.replace_borders = _counting
+
+    br.run(process_all=True)
+    assert calls["n"] == 0  # missing source -> skipped before any encode
+    assert not (dest_dir / "ghost.jpg").exists()
+
+
+def test_subset_pass_only_borders_manifest_items(tmp_path, monkeypatch):
+    """With process_all=False and a manifest, only manifest items are
+    bordered; a matched, already-moved poster NOT in the manifest is left
+    untouched (webhook/adhoc stays subset-only)."""
+    import backend.modules.border_replacerr as border_mod
+    from backend.util.database.border_state import BorderState
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+
+    def _mkrow(id_, name):
+        src = src_dir / f"{name}.jpg"
+        Image.new("RGB", (1000, 1500), (10, 20, 30)).save(src, "JPEG")
+        return {
+            "id": id_,
+            "title": name,
+            "folder": name,
+            "matched": 1,
+            "original_file": str(src),
+            "renamed_file": str(dest_dir / f"{name}.jpg"),
+        }
+
+    in_manifest = _mkrow(1, "inman")
+    out_manifest = _mkrow(2, "outman")
+    by_id = {1: in_manifest, 2: out_manifest}
+    border_state = BorderState(logger=StubLogger(), db_path=str(tmp_path / "b.db"))
+
+    class _MediaTable:
+        def get_by_id(self, i):
+            return by_id.get(i)
+
+        def get_all(self):
+            return [in_manifest, out_manifest]
+
+    class _CollTable:
+        def get_by_id(self, i):
+            return None
+
+        def get_all(self):
+            return []
+
+    class _FakeDB:
+        def __init__(self):
+            self.media = _MediaTable()
+            self.collection = _CollTable()
+            self.holiday = SimpleNamespace(
+                get_status=lambda: {"last_active_holiday": None},
+                set_status=lambda *a, **k: None,
+            )
+            self.border = border_state
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(border_mod, "ChubDB", lambda *a, **k: _FakeDB())
+    monkeypatch.setattr(
+        border_mod,
+        "NotificationManager",
+        lambda *a, **k: SimpleNamespace(send_notification=lambda *a, **k: None),
+    )
+
+    br = _make_br()
+    br.full_config = SimpleNamespace()
+    br.config = SimpleNamespace(
+        log_level="info",
+        holidays=[],
+        border_colors=["#FF0000"],
+        skip=False,
+        exclusion_list=[],
+        ignore_folders=[],
+        dry_run=False,
+        border_width=26,
+        border_workers=1,
+    )
+
+    manifest = {"media_cache": [1], "collections_cache": []}
+    br.run(manifest, process_all=False)
+
+    assert (dest_dir / "inman.jpg").exists()        # manifest item bordered
+    assert not (dest_dir / "outman.jpg").exists()   # non-manifest item untouched

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -278,3 +278,22 @@ def test_collect_matched_assets_applies_exclusion_and_ignore_filters():
     )
     assets = br._collect_matched_assets(_StubDB(media, []))
     assert {a["title"] for a in assets} == {"Keep"}
+
+
+# ---- selection rule: full-library vs manifest subset -----------------------
+
+
+@pytest.mark.parametrize(
+    "manifest,process_all,reset_all,expected",
+    [
+        ({"media_cache": [1]}, False, False, False),  # webhook/adhoc subset
+        ({"media_cache": [1]}, True, False, True),    # renamerr full run
+        ({"media_cache": [1]}, False, True, True),    # holiday transition
+        (None, False, False, True),                   # standalone run (no manifest)
+    ],
+)
+def test_should_process_all(manifest, process_all, reset_all, expected):
+    assert (
+        BorderReplacerr._should_process_all(manifest, process_all, reset_all)
+        is expected
+    )

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -2,6 +2,7 @@
 
 import pytest
 from PIL import Image
+from types import SimpleNamespace
 
 from backend.modules.border_replacerr import (
     _BUNDLED_BORDERS_DIR,
@@ -204,8 +205,6 @@ def test_border_state_roundtrip_and_upsert(tmp_path):
 
 
 # ---- full-library asset collection -----------------------------------------
-
-from types import SimpleNamespace
 
 
 class _StubTable:

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -201,3 +201,81 @@ def test_border_state_roundtrip_and_upsert(tmp_path):
 
     bs.clear()
     assert bs.get_all_map() == {}
+
+
+# ---- full-library asset collection -----------------------------------------
+
+from types import SimpleNamespace
+
+
+class _StubTable:
+    """Stands in for db.media / db.collection with a get_all()."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_all(self):
+        return self._rows
+
+
+class _StubDB:
+    def __init__(self, media=None, collections=None):
+        self.media = _StubTable(media or [])
+        self.collection = _StubTable(collections or [])
+
+
+def _make_br_with_config(exclusion_list=None, ignore_folders=None):
+    br = _make_br()
+    br.config = SimpleNamespace(
+        exclusion_list=exclusion_list or [],
+        ignore_folders=ignore_folders or [],
+    )
+    return br
+
+
+def test_collect_matched_assets_includes_moved_and_collections(tmp_path):
+    """The full pass must include matched posters that are ALREADY MOVED
+    (renamed_file exists on disk) and matched collections — the exact set
+    get_matched_assets() drops. This is the core regression guard."""
+    moved_dest = tmp_path / "Movie (2020)" / "poster.jpg"
+    moved_dest.parent.mkdir(parents=True)
+    moved_dest.write_bytes(b"already-moved")
+
+    media = [
+        {
+            "title": "Moved Movie",
+            "folder": "Movie (2020)",
+            "matched": 1,
+            "original_file": str(tmp_path / "src" / "movie.jpg"),
+            "renamed_file": str(moved_dest),  # exists on disk == "moved"
+        },
+        {"title": "Unmatched", "folder": "x", "matched": 0},
+    ]
+    collections = [
+        {
+            "title": "My Collection",
+            "folder": "",
+            "matched": 1,
+            "original_file": str(tmp_path / "src" / "coll.jpg"),
+            "renamed_file": str(tmp_path / "dest" / "My Collection.jpg"),
+        }
+    ]
+
+    br = _make_br_with_config()
+    assets = br._collect_matched_assets(_StubDB(media, collections))
+
+    titles = {a["title"] for a in assets}
+    assert titles == {"Moved Movie", "My Collection"}  # moved + collection in; unmatched out
+
+
+def test_collect_matched_assets_applies_exclusion_and_ignore_filters():
+    media = [
+        {"title": "Keep", "folder": "keepdir", "matched": 1},
+        {"title": "ByTitle", "folder": "okdir", "matched": 1},
+        {"title": "ByFolder", "folder": "skipdir", "matched": 1},
+    ]
+    br = _make_br_with_config(
+        exclusion_list=["ByTitle"], ignore_folders=["skipdir"]
+    )
+    assets = br._collect_matched_assets(_StubDB(media, []))
+    assert {a["title"] for a in assets} == {"Keep"}

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -297,3 +297,40 @@ def test_should_process_all(manifest, process_all, reset_all, expected):
         BorderReplacerr._should_process_all(manifest, process_all, reset_all)
         is expected
     )
+
+
+# ---- poster_renamerr wiring ------------------------------------------------
+
+
+def test_renamerr_run_border_replacerr_forwards_process_all(monkeypatch):
+    """poster_renamerr.run_border_replacerr must forward process_all into
+    BorderReplacerr.run so a full renamerr run sweeps the whole library."""
+    import backend.modules.border_replacerr as border_mod
+    from backend.modules.poster_renamerr import PosterRenamerr
+
+    captured = {}
+
+    class _FakeBorder:
+        def __init__(self, logger=None):
+            pass
+
+        def set_job_context(self, *a, **k):
+            pass
+
+        def set_progress_window(self, *a, **k):
+            pass
+
+        def run(self, manifest=None, process_all=False):
+            captured["manifest"] = manifest
+            captured["process_all"] = process_all
+
+    monkeypatch.setattr(border_mod, "BorderReplacerr", _FakeBorder)
+
+    renamer = PosterRenamerr.__new__(PosterRenamerr)
+    renamer.logger = StubLogger()
+
+    manifest = {"media_cache": [1, 2], "collections_cache": []}
+    renamer.run_border_replacerr(manifest, process_all=True)
+
+    assert captured["process_all"] is True
+    assert captured["manifest"] == manifest


### PR DESCRIPTION
## Summary

Border Replacerr only ever bordered posters **before they were moved** into the destination. The chained border step receives a manifest built from `get_matched_assets`, which excludes any matched poster whose `renamed_file` already exists on disk — so once a poster is in place it's never re-bordered (except on a holiday transition). This makes a poster_renamerr run with **"run border replacerr when done"** re-apply the current border state to the **entire matched library** (media **and** collections), including already-moved posters, while doing **no work for posters that don't need it**.

- `BorderReplacerr.run(manifest=None, process_all=False)` now selects the full matched set via a new `_collect_matched_assets(db)` when `_should_process_all(manifest, process_all, reset_all)` is true (`process_all` OR holiday `reset_all` OR no manifest); otherwise the manifest subset (unchanged).
- `poster_renamerr` passes `process_all=True` only at the full-run call site. The **webhook/adhoc** path is untouched, so webhooks stay subset-only.
- "Only re-border what needs it" is enforced by the existing skip-gate (source mtime/size + border signature) and `_save_if_changed` content-compare, both kept enabled; gate records are persisted for rendered-but-unchanged posters so repeat sweeps re-encode nothing.
- Side effects: the old `reset_all` full path now also includes **collections** (was media-only); a bare `border_replacerr.run()` (standalone module run) no longer raises `TypeError`; a moved poster whose source is missing on disk is now counted as **skipped**, not **failed**.

## Related issue

N/A

## Type of change

- [x] New feature (non-breaking)

## Testing

- Added unit + integration tests in `tests/test_border_replacerr.py`:
  - `_collect_matched_assets` includes already-moved posters + collections; applies exclusion_list/ignore_folders.
  - `_should_process_all` selection rule (parametrized).
  - `run_border_replacerr` forwards `process_all`.
  - End-to-end: first full pass borders all; **second identical pass re-encodes nothing** (gate fires) with byte-identical output.
  - Subset isolation: `process_all=False` + manifest borders only manifest items; a moved poster not in the manifest is left untouched.
  - Missing-source poster is skipped, not failed.
- `tests/test_border_replacerr.py`: 27 passed. Full backend suite: 865 passed, 1 pre-existing unrelated failure (`test_nohl.py` uses `PosixPath.link_to`, removed in Python 3.12+; fails identically on `main`).
- `ruff check` clean on all changed files.

## Checklist

- [ ] Config schema updated if applicable (`backend/util/config.py`) — N/A, no new config
- [ ] Frontend builds cleanly — N/A, backend-only
- [x] No new `DAPS` references introduced
- [ ] Docs / wiki drafts updated if behavior or shape changed — wiki update may be wanted (full-library sweep behavior)
- [ ] CHANGELOG entry added — handled by release-please from the conventional commits