### PR TITLE
Music (Lidarr) support: custom artist/album artwork → Plex/Plexamp + maintenance parity

### DIFF
--- a/backend/modules/asset_renamerr.py
+++ b/backend/modules/asset_renamerr.py
@@ -374,8 +374,10 @@ class AssetRenamerr(ChubModule):
         from backend.modules.poster_renamerr import build_asset_record
 
         active = set(self._active_asset_types())
-        source_dirs = self.config.source_dirs or []
-        for priority, source_dir in enumerate(source_dirs):
+        regular = self.config.source_dirs or []
+        music_dirs = list(getattr(self.config, "music_source_dirs", []) or [])
+        scan_plan = [(d, False) for d in regular] + [(d, True) for d in music_dirs]
+        for priority, (source_dir, is_music) in enumerate(scan_plan):
             if not source_dir or not os.path.isdir(source_dir):
                 self.logger.warning(f"Source dir not found: '{source_dir}'")
                 continue
@@ -390,10 +392,15 @@ class AssetRenamerr(ChubModule):
                 for fname in sorted(files, key=str.lower):
                     if not fname.lower().endswith((".jpg", ".jpeg", ".png", ".webp")):
                         continue
-                    record = build_asset_record(fname, root, priority=priority)
+                    record = build_asset_record(
+                        fname,
+                        root,
+                        priority=priority,
+                        music_root=source_dir if is_music else None,
+                    )
                     if record.get("image_type") in active:
-                        # classify asset_type (movie/show/collection) per-record;
-                        # season detection is already in the record.
+                        # classify asset_type per-record; music records are
+                        # pre-classified (artist/album) by the builder.
                         record["asset_type"] = self._classify(record)
                         records.append(record)
             # Batch the upserts: one transaction per chunk, not per row.
@@ -402,6 +409,8 @@ class AssetRenamerr(ChubModule):
 
     @staticmethod
     def _classify(record: dict) -> str:
+        if record.get("music_kind"):
+            return record["music_kind"]
         if record.get("season_number") is not None or record.get("tvdb_id"):
             return "show"
         if record.get("year") is None:

--- a/backend/modules/asset_renamerr.py
+++ b/backend/modules/asset_renamerr.py
@@ -128,7 +128,13 @@ class AssetRenamerr(ChubModule):
         return out
 
     # media asset_type -> the Plex library type that can actually hold it.
-    _PLEX_SECTION_TYPE = {"movie": "movie", "show": "show"}
+    # Artists and albums both live in "artist" (music) libraries.
+    _PLEX_SECTION_TYPE = {
+        "movie": "movie",
+        "show": "show",
+        "artist": "artist",
+        "album": "artist",
+    }
 
     def _get_plex_index(self, db: ChubDB, instance_name: str):
         """Build (once per run, cached) a PlexMediaIndex over this instance's
@@ -169,6 +175,8 @@ class AssetRenamerr(ChubModule):
             media_type = "movie"
         elif asset_type == "show":
             media_type = "season" if season_number is not None else "show"
+        elif asset_type in ("artist", "album"):
+            media_type = asset_type
         else:
             return None  # collections resolve via their own instance/library
         entries, _key = index.resolve(
@@ -858,6 +866,11 @@ class AssetRenamerr(ChubModule):
                     and media.get("asset_type") == "show"
                     and media.get("season_number") is not None
                 ):
+                    continue
+                # Albums likewise have no logos — providers publish artist-level
+                # logos only. Skip album+logo so it never sits as permanently
+                # "missing". Artist logos and album backgrounds are supported.
+                if image_type == "logo" and media.get("asset_type") == "album":
                     continue
                 # Manual-pick lock: when the user chose a specific file in the
                 # picker, reuse it verbatim instead of re-resolving — a re-run

--- a/backend/modules/border_replacerr.py
+++ b/backend/modules/border_replacerr.py
@@ -236,25 +236,30 @@ class BorderReplacerr(ChubModule):
             raise
 
     def replace_borders_with_image(
-        self, original_file: str, renamed_file: str, border_image_path: str
+        self,
+        original_file: str,
+        renamed_file: str,
+        border_image_path: str,
+        target_size: Tuple[int, int] = (1000, 1500),
     ) -> bool:
-        """Composite a 1000×1500 PNG border over a poster.
+        """Composite a PNG border over a poster at ``target_size``.
 
         The border PNG must have an opaque decorated outer ring and a
-        transparent rectangular center where the poster shows through.
-        Final output is 1000×1500 RGB.
+        transparent rectangular center where the poster shows through. Final
+        output is ``target_size`` RGB — portrait 1000×1500 for posters/artist
+        art, square 1000×1000 for album covers.
         """
         try:
             with Image.open(original_file) as image:
                 # Skip the resample when the source is already target size
-                # (often, since our own output is 1000x1500).
-                if image.size != (1000, 1500):
-                    image = image.resize((1000, 1500))
+                # (often, since our own output is the same size).
+                if image.size != target_size:
+                    image = image.resize(target_size)
                 poster = image.convert("RGBA")
             with Image.open(border_image_path) as border:
                 overlay = border.convert("RGBA")
-                if overlay.size != (1000, 1500):
-                    overlay = overlay.resize((1000, 1500))
+                if overlay.size != target_size:
+                    overlay = overlay.resize(target_size)
             out_img = Image.alpha_composite(poster, overlay).convert("RGB")
             if self._save_if_changed(out_img, renamed_file):
                 self.logger.debug(
@@ -277,7 +282,14 @@ class BorderReplacerr(ChubModule):
             # can tally it instead of silently counting it as processed.
             return None
 
-    def replace_borders(self, original_file, renamed_file, border_color, border_width):
+    def replace_borders(
+        self,
+        original_file,
+        renamed_file,
+        border_color,
+        border_width,
+        target_size: Tuple[int, int] = (1000, 1500),
+    ):
         try:
             with Image.open(original_file) as image:
                 width, height = image.size
@@ -293,8 +305,8 @@ class BorderReplacerr(ChubModule):
                 new_height = cropped.height + 2 * border_width
                 out_img = Image.new("RGB", (new_width, new_height), border_color)
                 out_img.paste(cropped, (border_width, border_width))
-                if out_img.size != (1000, 1500):
-                    out_img = out_img.resize((1000, 1500))
+                if out_img.size != target_size:
+                    out_img = out_img.resize(target_size)
                 out_img = out_img.convert("RGB")
 
                 if self._save_if_changed(out_img, renamed_file):
@@ -314,7 +326,13 @@ class BorderReplacerr(ChubModule):
             )
             return None  # None = failure (vs False = no change needed)
 
-    def remove_borders(self, original_file, renamed_file, border_width):
+    def remove_borders(
+        self,
+        original_file,
+        renamed_file,
+        border_width,
+        target_size: Tuple[int, int] = (1000, 1500),
+    ):
         try:
             with Image.open(original_file) as image:
                 width, height = image.size
@@ -326,8 +344,8 @@ class BorderReplacerr(ChubModule):
                         height - border_width,
                     )
                 )
-                if cropped.size != (1000, 1500):
-                    cropped = cropped.resize((1000, 1500))
+                if cropped.size != target_size:
+                    cropped = cropped.resize(target_size)
                 cropped = cropped.convert("RGB")
 
                 if self._save_if_changed(cropped, renamed_file):
@@ -572,6 +590,13 @@ class BorderReplacerr(ChubModule):
                 original_file = asset["original_file"]
                 renamed_file = asset["renamed_file"]
                 title = asset["title"]
+                # Album covers are square (1:1); everything else stays portrait
+                # 1000×1500. Artist posters are portrait, so only "album" flips.
+                target_size = (
+                    (1000, 1000)
+                    if asset.get("asset_type") == "album"
+                    else (1000, 1500)
+                )
                 if border_paths:
                     action, detail = "composited", os.path.basename(variant)
                     if dry_run:
@@ -580,7 +605,7 @@ class BorderReplacerr(ChubModule):
                         )
                         return True, title, action, detail, original_file, renamed_file, sig
                     result = self.replace_borders_with_image(
-                        original_file, renamed_file, variant
+                        original_file, renamed_file, variant, target_size
                     )
                 elif border_colors:
                     action, detail = "replaced", variant
@@ -590,7 +615,11 @@ class BorderReplacerr(ChubModule):
                         )
                         return True, title, action, detail, original_file, renamed_file, sig
                     result = self.replace_borders(
-                        original_file, renamed_file, variant, self.config.border_width
+                        original_file,
+                        renamed_file,
+                        variant,
+                        self.config.border_width,
+                        target_size,
                     )
                 else:
                     action, detail = "removed", ""
@@ -600,7 +629,10 @@ class BorderReplacerr(ChubModule):
                         )
                         return True, title, action, detail, original_file, renamed_file, sig
                     result = self.remove_borders(
-                        original_file, renamed_file, self.config.border_width
+                        original_file,
+                        renamed_file,
+                        self.config.border_width,
+                        target_size,
                     )
                 return result, title, action, detail, original_file, renamed_file, sig
 

--- a/backend/modules/poster_renamerr.py
+++ b/backend/modules/poster_renamerr.py
@@ -819,13 +819,15 @@ class PosterRenamerr(ChubModule):
         elif asset_type == "album":
             # Albums share their artist's folder, so a bare "poster" name would
             # clobber the artist poster (and sibling albums). Stage each album
-            # under a sanitized album-title filename. (Plex-direct upload reads
-            # this staged file by ratingKey; the on-disk Kometa music layout is
-            # out of scope for v1.)
-            album_base = (
-                illegal_chars_regex.sub("", item.get("title") or "").strip()
-                or "album"
-            )
+            # under a sanitized "<Artist> - <Album>" filename — the artist is
+            # included so two artists' identically-titled albums staged from a
+            # shared flat folder don't collide and overwrite each other before
+            # upload. (Plex-direct upload reads this staged file by ratingKey;
+            # the on-disk Kometa music layout is out of scope for v1.)
+            parent = illegal_chars_regex.sub("", item.get("parent_title") or "").strip()
+            album = illegal_chars_regex.sub("", item.get("title") or "").strip()
+            album_base = f"{parent} - {album}".strip(" -") if parent else album
+            album_base = album_base or "album"
             if config.asset_folders:
                 new_file_name = f"{album_base}{file_extension}"
             else:

--- a/backend/modules/poster_renamerr.py
+++ b/backend/modules/poster_renamerr.py
@@ -334,7 +334,7 @@ class PosterRenamerr(ChubModule):
         # ambiguous (conflicting-identity) matches.
         matched_candidates = []
 
-        for id_field in ["imdb_id", "tmdb_id", "tvdb_id"]:
+        for id_field in ["imdb_id", "tmdb_id", "tvdb_id", "musicbrainz_id"]:
             id_val = media.get(id_field)
             if id_val:
                 c = db.poster.get_by_id(
@@ -685,6 +685,21 @@ class PosterRenamerr(ChubModule):
             else:
                 new_file_name = f"{folder}_Season{season_str}{file_extension}"
             new_file_path = os.path.join(dest_dir, new_file_name)
+        elif asset_type == "album":
+            # Albums share their artist's folder, so a bare "poster" name would
+            # clobber the artist poster (and sibling albums). Stage each album
+            # under a sanitized album-title filename. (Plex-direct upload reads
+            # this staged file by ratingKey; the on-disk Kometa music layout is
+            # out of scope for v1.)
+            album_base = (
+                illegal_chars_regex.sub("", item.get("title") or "").strip()
+                or "album"
+            )
+            if config.asset_folders:
+                new_file_name = f"{album_base}{file_extension}"
+            else:
+                new_file_name = f"{folder}_{album_base}{file_extension}"
+            new_file_path = os.path.join(dest_dir, new_file_name)
         else:
             if config.asset_folders:
                 new_file_name = f"poster{file_extension}"
@@ -843,6 +858,8 @@ class PosterRenamerr(ChubModule):
             "collection": [],
             "movie": [],
             "show": [],
+            "artist": [],
+            "album": [],
         }
         manifest = {"media_cache": [], "collections_cache": []}
         matched_assets = self.get_matched_assets(db=db)
@@ -863,7 +880,9 @@ class PosterRenamerr(ChubModule):
                         break
                     result = self.rename_file(item=item, db=db)
                     if result:
-                        output[item.get("asset_type", "movie")].append(result)
+                        output.setdefault(
+                            item.get("asset_type", "movie"), []
+                        ).append(result)
 
                     if item.get("asset_type") == "collection":
                         manifest["collections_cache"].append(item.get("id"))
@@ -882,8 +901,14 @@ class PosterRenamerr(ChubModule):
         return output, manifest
 
     def handle_output(self, output: Dict[str, List[Dict[str, Any]]]):
-        headers = {"collection": "Collection", "movie": "Movie", "show": "Show"}
-        for asset_type in ["collection", "movie", "show"]:
+        headers = {
+            "collection": "Collection",
+            "movie": "Movie",
+            "show": "Show",
+            "artist": "Artist",
+            "album": "Album",
+        }
+        for asset_type in ["collection", "movie", "show", "artist", "album"]:
             assets = output.get(asset_type, [])
             header = f"{headers.get(asset_type, asset_type.capitalize())}s"
             self.logger.info(create_table([[header]]))
@@ -1256,7 +1281,13 @@ class PosterRenamerr(ChubModule):
                     self.merge_gdrive_search_index(db)
 
                 # Process each media item
-                output = {"collection": [], "movie": [], "show": []}
+                output = {
+                    "collection": [],
+                    "movie": [],
+                    "show": [],
+                    "artist": [],
+                    "album": [],
+                }
                 manifest = {"media_cache": [], "collections_cache": []}
 
                 matched_count = 0
@@ -1279,7 +1310,7 @@ class PosterRenamerr(ChubModule):
 
                             if rename_result:
                                 asset_type = updated_item.get("asset_type", "movie")
-                                output[asset_type].append(rename_result)
+                                output.setdefault(asset_type, []).append(rename_result)
 
                                 # Add to manifest
                                 if asset_type == "collection":

--- a/backend/modules/poster_renamerr.py
+++ b/backend/modules/poster_renamerr.py
@@ -22,6 +22,7 @@ from backend.util.helper import (
     classify_match,
     create_table,
     extract_ids,
+    extract_mbid,
     extract_year,
     is_match,
     normalize_titles,
@@ -43,12 +44,116 @@ from backend.util.upload_posters import PosterUploader
 _POSTER_CACHE_REBUILD_LOCK = threading.Lock()
 
 
+# Filenames (sans extension/suffix) that denote artist-level art in a music
+# folder layout; everything else at album depth is an album cover.
+_MUSIC_ARTIST_STEMS = {
+    "artist",
+    "artist-poster",
+    "poster",
+    "folder",
+    "fanart",
+    "background",
+    "banner",
+    "logo",
+    "clearlogo",
+}
+
+
+def _strip_mbid_tag(text: str) -> str:
+    """Remove an ``{mbid-<uuid>}`` (or bare ``mbid-<uuid>``) tag from text."""
+    from backend.util.constants import mbid_id_regex
+
+    cleaned = mbid_id_regex.sub("", text)
+    return cleaned.replace("{}", "").replace("[]", "").strip(" -_{}[]")
+
+
+def _build_music_asset_record(
+    fname: str,
+    root: str,
+    *,
+    music_root: Optional[str],
+    mbid: Optional[str],
+    image_type: str,
+    base: str,
+    ext: str,
+    style: Optional[str],
+    priority: int,
+    search_only: int,
+) -> dict:
+    """Parse one music image file (artist poster / album cover / asset) into a
+    poster_cache record carrying asset_type + musicbrainz_id + parent linkage.
+
+    Identity is resolved from (in priority): an ``{mbid-<uuid>}`` tag, then the
+    folder layout under ``music_root`` (``<Artist>/`` = artist, ``<Artist>/
+    <Album>/`` = album), then a flat ``Artist - Album`` / ``Artist`` filename.
+    """
+    folder = os.path.basename(root)
+    stem = _strip_mbid_tag(base)
+    artist_title: Optional[str] = None
+    album_title: Optional[str] = None
+
+    rel_parts: List[str] = []
+    if music_root:
+        rel = os.path.relpath(root, music_root)
+        rel_parts = [p for p in rel.split(os.sep) if p not in (".", "")]
+
+    if len(rel_parts) >= 2:
+        # <music_root>/<Artist>/<Album>/<file>
+        artist_title, album_title = rel_parts[0], rel_parts[1]
+    elif len(rel_parts) == 1:
+        # <music_root>/<Artist>/<file> — artist art, unless a clearly album-y
+        # stem sits here (rare); default to artist at this depth.
+        artist_title = rel_parts[0]
+        if stem and stem.lower() not in _MUSIC_ARTIST_STEMS:
+            # e.g. <Artist>/<Album>.jpg flat-in-artist-folder layout.
+            album_title = stem
+    else:
+        # Flat file: "Artist - Album.jpg" => album; "Artist.jpg" => artist.
+        if " - " in stem:
+            artist_title, album_title = (p.strip() for p in stem.split(" - ", 1))
+        else:
+            artist_title = stem
+
+    if album_title:
+        asset_type = "album"
+        title = album_title
+        parent_title = artist_title
+    else:
+        asset_type = "artist"
+        title = artist_title or stem
+        parent_title = None
+
+    return {
+        "title": title,
+        "normalized_title": normalize_titles(title or ""),
+        "year": None,
+        "tmdb_id": None,
+        "tvdb_id": None,
+        "imdb_id": None,
+        "musicbrainz_id": mbid,
+        "parent_musicbrainz_id": None,
+        "parent_title": parent_title,
+        "parent_normalized_title": (
+            normalize_titles(parent_title) if parent_title else None
+        ),
+        "season_number": None,
+        "music_kind": asset_type,
+        "folder": folder,
+        "file": os.path.join(root, fname),
+        "style": style,
+        "priority": priority,
+        "image_type": image_type,
+        "search_only": search_only,
+    }
+
+
 def build_asset_record(
     fname: str,
     root: str,
     style: Optional[str] = None,
     priority: int = 0,
     search_only: int = 0,
+    music_root: Optional[str] = None,
 ) -> dict:
     """Parse one image file into a poster_cache record.
 
@@ -62,6 +167,11 @@ def build_asset_record(
     the original inline logic — do not let it drift. ``asset_type``
     (movie/show/collection) is NOT set here; it is classified across the full
     record set by the caller (it needs cross-record show_keys).
+
+    When ``music_root`` is set (the file lives under a configured music source
+    dir) or the file/folder carries an ``{mbid-<uuid>}`` tag, the record is
+    built as MUSIC (artist poster / album cover) via _build_music_asset_record
+    and stamped with ``music_kind`` so the caller classifies it as artist/album.
     """
     folder = os.path.basename(root)
     filename, ext = os.path.splitext(fname)
@@ -73,10 +183,31 @@ def build_asset_record(
         # parse_asset_filename's own splitext targets the extension (not a dot
         # inside a title like "8 A.M. Metro").
         base = asset_type_regex.sub("", filename).strip(" -_")
+    else:
+        image_type = "poster"
+        base = filename
+
+    # Music: a configured music_root, or an {mbid-} tag anywhere, routes to the
+    # music builder.
+    mbid = extract_mbid(fname) or extract_mbid(folder)
+    if music_root is not None or mbid:
+        return _build_music_asset_record(
+            fname,
+            root,
+            music_root=music_root,
+            mbid=mbid,
+            image_type=image_type,
+            base=base,
+            ext=ext,
+            style=style,
+            priority=priority,
+            search_only=search_only,
+        )
+
+    if m:
         title = parse_asset_filename(base + ext)
         normalized_title = normalize_titles(base)
     else:
-        image_type = "poster"
         title = parse_asset_filename(fname)
         # Derive the search/match key from the raw (ext-stripped) filename, not
         # from `title`. normalize_titles() already strips the year (and trailing
@@ -946,6 +1077,10 @@ class PosterRenamerr(ChubModule):
                     self.logger.info("")
 
     def _classify_asset_record(self, record: dict, show_keys: set) -> str:
+        # Music records are pre-classified by the builder (artist/album) — the
+        # show/movie/collection heuristics below don't apply to them.
+        if record.get("music_kind"):
+            return record["music_kind"]
         if record.get("season_number") is not None or record.get("tvdb_id"):
             return "show"
 
@@ -1002,6 +1137,7 @@ class PosterRenamerr(ChubModule):
         priority: int = 0,
         include_assets: bool = False,
         search_only: int = 0,
+        music: bool = False,
     ):
         """Walk source_dir and parse each image into a cache record.
 
@@ -1035,6 +1171,7 @@ class PosterRenamerr(ChubModule):
                     style=style,
                     priority=priority,
                     search_only=search_only,
+                    music_root=source_dir if music else None,
                 )
                 if not include_assets and record.get("image_type") != "poster":
                     continue
@@ -1076,15 +1213,22 @@ class PosterRenamerr(ChubModule):
         # up front so each per-asset write contributes a proportional slice.
         # The dir-walk to count is fast (no DB ops) and lets us update job
         # progress smoothly instead of in big steps per source_dir.
+        # Music source dirs (custom artist/album art) are scanned with the
+        # music classifier appended after the regular dirs so their bottom-wins
+        # priority is highest. They feed the same poster_cache.
+        music_dirs = list(getattr(self.config, "music_source_dirs", []) or [])
+        scan_plan = [(d, False) for d in source_dirs] + [(d, True) for d in music_dirs]
+
         per_dir_assets = []
         total_all = 0
-        for idx, source_dir in enumerate(source_dirs):
+        for idx, (source_dir, is_music) in enumerate(scan_plan):
             if self.is_cancelled():
                 break
             assets = self._get_assets_files(
                 source_dir,
                 priority=idx,
                 include_assets=getattr(self.config, "run_asset_renamerr", False),
+                music=is_music,
             )
             per_dir_assets.append((source_dir, assets))
             total_all += len(assets)

--- a/backend/modules/renameinatorr.py
+++ b/backend/modules/renameinatorr.py
@@ -424,7 +424,7 @@ class Renameinatorr(ChubModule):
                 self.logger.info("")
 
             output = {}
-            for instance_type in ["radarr", "sonarr"]:
+            for instance_type in ["radarr", "sonarr", "lidarr"]:
                 instance_dict = getattr(self.full_config.instances, instance_type, {})
                 for instance_name, instance_cfg in instance_dict.items():
                     if instance_name in self.config.instances:

--- a/backend/util/arr.py
+++ b/backend/util/arr.py
@@ -1744,6 +1744,138 @@ class LidarrClient(BaseARRClient):
         }
         return self.make_delete_request(endpoint, params=params)
 
+    def delete_track_file(self, track_file_ids: Union[int, List[int]]) -> Any:
+        """Delete one or more track files by their file IDs.
+
+        Mirrors Sonarr's ``delete_episode_files`` (bulk endpoint). Used by NoHL
+        to remove the wasteful non-hardlinked library copy before re-grabbing a
+        properly linked release. Operates on track *files* only — the artist and
+        album records are untouched.
+        """
+        if isinstance(track_file_ids, int):
+            track_file_ids = [track_file_ids]
+        payload = {"trackFileIds": track_file_ids}
+        self.logger.debug(f"Delete track files payload: {payload}")
+        endpoint = f"{self.api_base}/trackfile/bulk"
+        return self.make_delete_request(endpoint, payload)
+
+    def get_rename_list(self, media_id: int, threadsafe: bool = False) -> Any:
+        """
+        Preview renaming for an artist's tracks.
+
+        Args:
+            media_id (int): Artist ID.
+            threadsafe (bool): Use a private session for concurrent calls.
+        Returns:
+            Any: List of rename items, each with ``trackFileId`` plus
+                ``existingPath``/``newPath``.
+        """
+        endpoint = f"{self.api_base}/rename?artistId={media_id}"
+        return self._requester(threadsafe)(endpoint, headers=self.headers)
+
+    def rename_media(self, media_ids: List[int]) -> Any:
+        """
+        Trigger renaming of artists' track files.
+
+        Unlike Radarr/Sonarr (which rename by movie/series ID via
+        ``RenameMovie``/``RenameSeries``), Lidarr's ``RenameFiles`` command is
+        per-artist and takes the explicit track-file IDs to rename. We derive
+        those from the rename preview, so passing the same artist-ID list the
+        renameinatorr loop already builds works transparently.
+
+        This renames the *library* copy to the existing naming scheme; it never
+        edits tags/content and respects hardlinks (the seeded download copy is a
+        separate hardlink to the same inode, untouched).
+
+        Args:
+            media_ids (List[int]): Artist IDs.
+        Returns:
+            Any: API response from the last command issued, or None.
+        """
+        endpoint = f"{self.api_base}/command"
+        result = None
+        for artist_id in media_ids:
+            preview = self.get_rename_list(artist_id) or []
+            file_ids = sorted(
+                {
+                    item.get("trackFileId")
+                    for item in preview
+                    if item.get("trackFileId") is not None
+                }
+            )
+            if not file_ids:
+                continue
+            payload = {
+                "name": "RenameFiles",
+                "artistId": artist_id,
+                "files": file_ids,
+            }
+            self.logger.debug(f"Rename payload: {payload}")
+            result = self.make_post_request(endpoint, json=payload)
+        return result
+
+    def rename_folders(self, media_ids: List[int], root_folder_path: str) -> Any:
+        """
+        Rename/move folders for given artists to the current naming scheme.
+
+        Args:
+            media_ids (List[int]): Artist IDs.
+            root_folder_path (str): Root folder path.
+        Returns:
+            Any: API response.
+        """
+        payload = {
+            "artistIds": media_ids,
+            "moveFiles": True,
+            "rootFolderPath": root_folder_path,
+        }
+        self.logger.debug(f"Rename Folder Payload: {payload}")
+        endpoint = f"{self.api_base}/artist/editor"
+        return self.make_put_request(endpoint, json=payload)
+
+    def get_mediacover_url(self, kind: str, media_id: int, file: str) -> str:
+        """Build a Lidarr mediacover URL for an artist or album image.
+
+        ``kind`` is ``"artist"`` or ``"album"``. Returns an absolute URL that
+        ``_upload_artwork(url=...)`` can push straight to Plex. Read-only source
+        only — Lidarr exposes no art-upload endpoint.
+        """
+        return f"{self.api_base}/mediacover/{kind}/{media_id}/{file}"
+
+    @staticmethod
+    def _extract_images(
+        images: Optional[List[Dict[str, Any]]], cover_map: Dict[str, str]
+    ) -> Dict[str, str]:
+        """Map an ARR ``images[]`` list to {plex_slot: url} via ``cover_map``.
+
+        ``cover_map`` maps Lidarr ``coverType`` values to CHUB image slots
+        (``poster``/``background``/``logo``). Prefers ``remoteUrl`` (the
+        upstream metadata-server URL) and falls back to the local ``url``.
+        """
+        result: Dict[str, str] = {}
+        for image in images or []:
+            slot = cover_map.get(image.get("coverType"))
+            if not slot:
+                continue
+            url = image.get("remoteUrl") or image.get("url")
+            if url:
+                result[slot] = url
+        return result
+
+    def extract_artist_images(self, artist: Dict[str, Any]) -> Dict[str, str]:
+        """Return {slot: url} for an artist (poster/fanart/logo)."""
+        return self._extract_images(
+            artist.get("images"),
+            {"poster": "poster", "fanart": "background", "logo": "logo"},
+        )
+
+    def extract_album_images(self, album: Dict[str, Any]) -> Dict[str, str]:
+        """Return {slot: url} for an album (cover → poster)."""
+        return self._extract_images(
+            album.get("images"),
+            {"cover": "poster"},
+        )
+
 
 def create_arr_client(
     url: str, api: str, logger: Any

--- a/backend/util/arr.py
+++ b/backend/util/arr.py
@@ -1833,49 +1833,6 @@ class LidarrClient(BaseARRClient):
         endpoint = f"{self.api_base}/artist/editor"
         return self.make_put_request(endpoint, json=payload)
 
-    def get_mediacover_url(self, kind: str, media_id: int, file: str) -> str:
-        """Build a Lidarr mediacover URL for an artist or album image.
-
-        ``kind`` is ``"artist"`` or ``"album"``. Returns an absolute URL that
-        ``_upload_artwork(url=...)`` can push straight to Plex. Read-only source
-        only — Lidarr exposes no art-upload endpoint.
-        """
-        return f"{self.api_base}/mediacover/{kind}/{media_id}/{file}"
-
-    @staticmethod
-    def _extract_images(
-        images: Optional[List[Dict[str, Any]]], cover_map: Dict[str, str]
-    ) -> Dict[str, str]:
-        """Map an ARR ``images[]`` list to {plex_slot: url} via ``cover_map``.
-
-        ``cover_map`` maps Lidarr ``coverType`` values to CHUB image slots
-        (``poster``/``background``/``logo``). Prefers ``remoteUrl`` (the
-        upstream metadata-server URL) and falls back to the local ``url``.
-        """
-        result: Dict[str, str] = {}
-        for image in images or []:
-            slot = cover_map.get(image.get("coverType"))
-            if not slot:
-                continue
-            url = image.get("remoteUrl") or image.get("url")
-            if url:
-                result[slot] = url
-        return result
-
-    def extract_artist_images(self, artist: Dict[str, Any]) -> Dict[str, str]:
-        """Return {slot: url} for an artist (poster/fanart/logo)."""
-        return self._extract_images(
-            artist.get("images"),
-            {"poster": "poster", "fanart": "background", "logo": "logo"},
-        )
-
-    def extract_album_images(self, album: Dict[str, Any]) -> Dict[str, str]:
-        """Return {slot: url} for an album (cover → poster)."""
-        return self._extract_images(
-            album.get("images"),
-            {"cover": "poster"},
-        )
-
 
 def create_arr_client(
     url: str, api: str, logger: Any

--- a/backend/util/arr.py
+++ b/backend/util/arr.py
@@ -2091,9 +2091,6 @@ def normalize_arr_media(
                         "foreign_album_id": album.get("foreignAlbumId", ""),
                         "monitored": album.get("monitored", False),
                         "episode_data": [],  # Albums don't have sub-items to search
-                        # Lidarr's own album cover (fanart.tv upstream) — used as
-                        # the optional music_art_from_lidarr fallback source.
-                        "poster_url": extract_poster_url(album),
                     }
                 )
 

--- a/backend/util/arr.py
+++ b/backend/util/arr.py
@@ -2134,6 +2134,9 @@ def normalize_arr_media(
                         "foreign_album_id": album.get("foreignAlbumId", ""),
                         "monitored": album.get("monitored", False),
                         "episode_data": [],  # Albums don't have sub-items to search
+                        # Lidarr's own album cover (fanart.tv upstream) — used as
+                        # the optional music_art_from_lidarr fallback source.
+                        "poster_url": extract_poster_url(album),
                     }
                 )
 

--- a/backend/util/config.py
+++ b/backend/util/config.py
@@ -127,9 +127,6 @@ class PosterRenamerrConfig(BaseModel):
     # background.jpg for artists) into the Plex music library folders for
     # refresh-proof art. Writes image files only; never audio.
     music_lma_sidecars: bool = False
-    # When no local/Google-Drive custom art matches, fall back to the art Lidarr
-    # already fetched (fanart.tv upstream) via its mediacover URL.
-    music_art_from_lidarr: bool = False
 
     @field_validator("action_type", mode="before")
     @classmethod

--- a/backend/util/config.py
+++ b/backend/util/config.py
@@ -106,6 +106,24 @@ class PosterRenamerrConfig(BaseModel):
     instances: List[Union[str, Dict[str, PosterRenamerrPlexInstance]]] = Field(
         default_factory=list
     )
+    # --- Music (Lidarr) artwork options ---
+    # Only meaningful when a Lidarr instance is configured; the frontend gates
+    # them on that. All are image-only / Plex-metadata operations — none ever
+    # touches audio, so seeded music torrents are never endangered.
+    #
+    # After a Plex-direct artist poster upload, lock thumb/art so Plex's music
+    # agent can't re-derive the artist image from album art on refresh.
+    # Artist-only; album covers are sticky and never need it.
+    music_lock_artist_art: bool = False
+    # Also write image-only sidecars (cover.jpg for albums, artist-poster.jpg /
+    # background.jpg for artists) into the Plex music library folders for
+    # refresh-proof art. Writes image files only; never audio.
+    music_lma_sidecars: bool = False
+    # When no local/Google-Drive custom art matches, fall back to the art Lidarr
+    # already fetched (fanart.tv upstream) via its mediacover URL.
+    music_art_from_lidarr: bool = False
+    # Ordered art-source preference for music. "local" = the user's custom art.
+    music_art_sources: List[str] = Field(default_factory=lambda: ["local"])
 
     @field_validator("action_type", mode="before")
     @classmethod

--- a/backend/util/config.py
+++ b/backend/util/config.py
@@ -130,8 +130,6 @@ class PosterRenamerrConfig(BaseModel):
     # When no local/Google-Drive custom art matches, fall back to the art Lidarr
     # already fetched (fanart.tv upstream) via its mediacover URL.
     music_art_from_lidarr: bool = False
-    # Ordered art-source preference for music. "local" = the user's custom art.
-    music_art_sources: List[str] = Field(default_factory=lambda: ["local"])
 
     @field_validator("action_type", mode="before")
     @classmethod

--- a/backend/util/config.py
+++ b/backend/util/config.py
@@ -102,6 +102,14 @@ class PosterRenamerrConfig(BaseModel):
     # behaviour). Only sleeps after an actual upload, never after a skip.
     upload_delay_ms: int = Field(default=0, ge=0, le=5000)
     source_dirs: List[str] = Field(default_factory=list)
+    # Source dirs whose contents are custom MUSIC art (artist posters / album
+    # covers). Files here are classified as artist/album by folder depth
+    # (<dir>/<Artist>/poster|artist.jpg, <dir>/<Artist>/<Album>/cover.jpg) or by
+    # a flat "Artist.jpg" / "Artist - Album.jpg" name; an {mbid-<uuid>} tag in
+    # the filename/folder overrides identity. (An {mbid-} tag is also honored in
+    # the regular source_dirs.) Kept separate so a flat "Title.jpg" is never
+    # mistaken for a movie poster.
+    music_source_dirs: List[str] = Field(default_factory=list)
     destination_dir: str = ""
     instances: List[Union[str, Dict[str, PosterRenamerrPlexInstance]]] = Field(
         default_factory=list
@@ -222,6 +230,9 @@ class AssetRenamerrConfig(BaseModel):
     asset_folders: bool = False  # per-title folders (kometa path)
     destination_dir: str = ""  # kometa path
     source_dirs: List[str] = Field(default_factory=list)  # local source
+    # Music art source dirs (artist backgrounds/logos), classified by folder
+    # depth / flat name / {mbid-} tag — see PosterRenamerrConfig.music_source_dirs.
+    music_source_dirs: List[str] = Field(default_factory=list)
     print_only_renames: bool = False
     sync_assets: bool = False  # run sync_gdrive first (standalone path)
     # Preferred languages for TMDB image selection, in priority order; the first

--- a/backend/util/connector.py
+++ b/backend/util/connector.py
@@ -423,12 +423,22 @@ class Connector:
                         rows_by_type.setdefault(
                             row.get("asset_type") or asset_type, []
                         ).append(row)
-                    for row_asset_type, rows in rows_by_type.items():
+                    # Always sync every asset_type this instance can emit, even
+                    # when a type is empty this run — otherwise sync_for_instance
+                    # (scoped to one asset_type) never runs for it and its stale
+                    # rows are never purged. A Lidarr artist can drop all albums,
+                    # so 'album' must still be synced (with []) to delete them.
+                    types_to_sync = set(rows_by_type)
+                    if asset_type == "artist":
+                        types_to_sync |= {"artist", "album"}
+                    else:
+                        types_to_sync.add(asset_type)
+                    for row_asset_type in types_to_sync:
                         self.db.media.sync_for_instance(
                             instance_config.name,
                             client.instance_type,
                             row_asset_type,
-                            rows,
+                            rows_by_type.get(row_asset_type, []),
                             logger,
                         )
 
@@ -541,10 +551,11 @@ class Connector:
                     album_row["parent_title"] = artist_title
                     album_row["arr_id"] = season.get("album_id")
                     album_row["monitored"] = season.get("monitored")
-                    # Album's own Lidarr cover URL (not the artist's), for the
-                    # optional music_art_from_lidarr fallback.
-                    if season.get("poster_url"):
-                        album_row["poster_url"] = season.get("poster_url")
+                    # Album's OWN Lidarr cover URL — set unconditionally so an
+                    # album with no cover is None rather than inheriting the
+                    # artist's poster_url (which the music_art_from_lidarr
+                    # fallback would otherwise push as the album cover).
+                    album_row["poster_url"] = season.get("poster_url")
                     # Album titles don't share the artist's alternate titles.
                     album_row["alternate_titles"] = None
                     album_row["normalized_alternate_titles"] = None

--- a/backend/util/connector.py
+++ b/backend/util/connector.py
@@ -551,11 +551,6 @@ class Connector:
                     album_row["parent_title"] = artist_title
                     album_row["arr_id"] = season.get("album_id")
                     album_row["monitored"] = season.get("monitored")
-                    # Album's OWN Lidarr cover URL — set unconditionally so an
-                    # album with no cover is None rather than inheriting the
-                    # artist's poster_url (which the music_art_from_lidarr
-                    # fallback would otherwise push as the album cover).
-                    album_row["poster_url"] = season.get("poster_url")
                     # Album titles don't share the artist's alternate titles.
                     album_row["alternate_titles"] = None
                     album_row["normalized_alternate_titles"] = None

--- a/backend/util/connector.py
+++ b/backend/util/connector.py
@@ -541,6 +541,10 @@ class Connector:
                     album_row["parent_title"] = artist_title
                     album_row["arr_id"] = season.get("album_id")
                     album_row["monitored"] = season.get("monitored")
+                    # Album's own Lidarr cover URL (not the artist's), for the
+                    # optional music_art_from_lidarr fallback.
+                    if season.get("poster_url"):
+                        album_row["poster_url"] = season.get("poster_url")
                     # Album titles don't share the artist's alternate titles.
                     album_row["alternate_titles"] = None
                     album_row["normalized_alternate_titles"] = None

--- a/backend/util/connector.py
+++ b/backend/util/connector.py
@@ -388,8 +388,14 @@ class Connector:
                     "Lidarr": "artist",
                 }.get(client.instance_type, "show")
 
-                # Get all media with built-in retry logic from improved ARR client
-                raw_media = client.get_all_media()
+                # Get all media with built-in retry logic from improved ARR client.
+                # Lidarr needs include_episode=True so each artist's albums are
+                # fetched (one parallel /album call per artist) and surface as
+                # asset_type="album" rows; Radarr/Sonarr carry their child data
+                # in the main payload, so they stay on the cheap path.
+                raw_media = client.get_all_media(
+                    include_episode=(client.instance_type == "Lidarr")
+                )
                 if not raw_media:
                     return SyncResult(
                         instance_name=instance_config.name,
@@ -404,15 +410,27 @@ class Connector:
 
                 # Sync to database with enhanced metadata
                 # The sync_for_instance method will automatically use upsert_with_metadata
-                # when genres or cast_data are present in the media items
+                # when genres or cast_data are present in the media items.
+                #
+                # Partition by each row's own asset_type before syncing.
+                # sync_for_instance scopes its staleness comparison to one
+                # (instance, asset_type) pair, so Lidarr's mixed artist/album
+                # rows must be synced as two groups. Movies/shows are a single
+                # group, so this is a no-op for them.
                 try:
-                    self.db.media.sync_for_instance(
-                        instance_config.name,
-                        client.instance_type,
-                        asset_type,
-                        fresh_media,
-                        logger,
-                    )
+                    rows_by_type: Dict[str, List[Dict]] = {}
+                    for row in fresh_media:
+                        rows_by_type.setdefault(
+                            row.get("asset_type") or asset_type, []
+                        ).append(row)
+                    for row_asset_type, rows in rows_by_type.items():
+                        self.db.media.sync_for_instance(
+                            instance_config.name,
+                            client.instance_type,
+                            row_asset_type,
+                            rows,
+                            logger,
+                        )
 
                     return SyncResult(
                         instance_name=instance_config.name,
@@ -488,20 +506,44 @@ class Connector:
                         season_row["cast_data"] = show["cast_data"]
                     fresh_media.append(season_row)
         elif asset_type == "artist":
-            # Create entries for main artist and each album, preserving all metadata
+            from backend.util.normalization import normalize_titles
+
+            # Create entries for the main artist and each album. Albums become
+            # first-class asset_type="album" rows keyed by their own MusicBrainz
+            # ID (foreign_album_id) and scoped to the parent artist, so custom
+            # album covers can be matched/applied independently. (This replaces
+            # the older dormant "artist"+positional-season_number album rows,
+            # which dropped the album identity and could never be matched.)
             for artist in raw_media:
                 # Main artist entry - preserve all metadata fields
                 artist_row = dict(artist)
                 artist_row["season_number"] = None
+                artist_row["parent_musicbrainz_id"] = None
+                artist_row["parent_title"] = None
                 fresh_media.append(artist_row)
+
+                artist_title = artist.get("title")
+                artist_mbid = artist.get("musicbrainz_id")
 
                 # Album entries - inherit metadata from parent artist.
                 # Lidarr normalize returns seasons=None when include_episode=False,
                 # so coerce to [] to avoid "NoneType is not iterable".
                 for season in artist.get("seasons") or []:
-                    album_row = dict(artist)  # Copy all parent artist metadata
-                    album_row["season_number"] = season.get("season_number")
-                    album_row["asset_type"] = "artist"
+                    album_title = season.get("album_title") or ""
+                    album_row = dict(artist)  # Copy parent artist metadata
+                    album_row["asset_type"] = "album"
+                    album_row["season_number"] = None
+                    album_row["title"] = album_title
+                    album_row["normalized_title"] = normalize_titles(album_title)
+                    # Album-level identity + parent linkage
+                    album_row["musicbrainz_id"] = season.get("foreign_album_id")
+                    album_row["parent_musicbrainz_id"] = artist_mbid
+                    album_row["parent_title"] = artist_title
+                    album_row["arr_id"] = season.get("album_id")
+                    album_row["monitored"] = season.get("monitored")
+                    # Album titles don't share the artist's alternate titles.
+                    album_row["alternate_titles"] = None
+                    album_row["normalized_alternate_titles"] = None
                     # Preserve genres and cast_data from parent artist for each album
                     if "genres" in artist:
                         album_row["genres"] = artist["genres"]

--- a/backend/util/constants.py
+++ b/backend/util/constants.py
@@ -78,6 +78,15 @@ tvdb_id_regex = re.compile(r"(?i)\btvdb(?:id[-_\s]*|[-_\s])(\d+)\b")
 # Matches strings like "imdb-tt1234567", "imdb_tt1234567", or "imdb tt1234567", capturing the "tt" plus digits as the IMDb ID
 imdb_id_regex: Pattern = re.compile(r"imdb[-_\s](tt\d+)")
 
+# Matches a MusicBrainz id tag: "mbid-<uuid>", "mbid_<uuid>", "mbid <uuid>",
+# "mbid:<uuid>" (case-insensitive), capturing the canonical UUID. Used to
+# identify custom music art (artist/album) by MusicBrainz id in a filename or
+# folder, mirroring the tmdb/tvdb id tags.
+mbid_id_regex: Pattern = re.compile(
+    r"(?i)\bmbid[-_\s:]*"
+    r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b"
+)
+
 # Remove bracketed blocks containing TMDB, TVDB, or IMDb IDs. The tmdb/tvdb
 # branches accept the optional "id" suffix (e.g. {tvdbid-123}) so block
 # stripping stays consistent with tmdb_id_regex/tvdb_id_regex extraction —
@@ -87,7 +96,8 @@ id_content_regex = re.compile(
     r"\s*[\{\[]\s*(?:"
     r"tmdb(?:id[-_\s]*|[-_\s])\d+|"
     r"tvdb(?:id[-_\s]*|[-_\s])\d+|"
-    r"imdb(?:[-_\s](?:tt)?\d+)"
+    r"imdb(?:[-_\s](?:tt)?\d+)|"
+    r"mbid[-_\s:]*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
     r")\s*[\}\]]",
     flags=re.IGNORECASE,
 )

--- a/backend/util/database/media_cache.py
+++ b/backend/util/database/media_cache.py
@@ -42,7 +42,12 @@ class MediaCache(DatabaseBase):
         musicbrainz = norm_str(item.get("musicbrainz_id"))
 
         # choose stable cross-source id
-        if asset_type == "artist" and musicbrainz:
+        if asset_type == "album" and musicbrainz:
+            # Album MBID is unique, but scope under the artist MBID when known
+            # so the identity is self-describing and collision-proof.
+            parent_mb = norm_str(item.get("parent_musicbrainz_id"))
+            id_tag = f"mb:{parent_mb}:{musicbrainz}" if parent_mb else f"mb:{musicbrainz}"
+        elif asset_type == "artist" and musicbrainz:
             id_tag = f"mb:{musicbrainz}"
         elif imdb:
             id_tag = f"imdb:{imdb.lower()}"
@@ -50,6 +55,14 @@ class MediaCache(DatabaseBase):
             id_tag = f"tmdb:{tmdb}"
         elif asset_type != "movie" and tvdb:
             id_tag = f"tvdb:{tvdb}"
+        elif asset_type == "album":
+            # No album MBID — fall back to a parent-scoped title so two artists'
+            # identically-named albums ("Greatest Hits") don't collide.
+            parent_norm = norm_str(
+                item.get("parent_normalized_title") or item.get("parent_title")
+            )
+            base = f"{parent_norm}::{title_key}" if parent_norm else title_key
+            id_tag = f"title:{base}|y:{year_key}"
         else:
             id_tag = f"title:{title_key}|y:{year_key}"
 
@@ -81,6 +94,8 @@ class MediaCache(DatabaseBase):
             "tvdb_id",
             "imdb_id",
             "musicbrainz_id",
+            "parent_musicbrainz_id",
+            "parent_title",
             "folder",
             "root_folder",
             "media_file",
@@ -147,14 +162,18 @@ class MediaCache(DatabaseBase):
             INSERT INTO media_cache
                 (identity_key, asset_type, title, normalized_title,
                 alternate_titles, normalized_alternate_titles,
-                year, tmdb_id, tvdb_id, imdb_id, musicbrainz_id, folder, root_folder, media_file, tags,
+                year, tmdb_id, tvdb_id, imdb_id, musicbrainz_id,
+                parent_musicbrainz_id, parent_title,
+                folder, root_folder, media_file, tags,
                 season_number, matched, instance_name, source, poster_url, arr_id,
                 status, rating, studio, edition, runtime, language, monitored, has_content, genre)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(identity_key)
             DO UPDATE SET
                 title=excluded.title,
                 year=excluded.year,
+                parent_musicbrainz_id=excluded.parent_musicbrainz_id,
+                parent_title=excluded.parent_title,
                 -- Refresh secondary IDs too: when the row is keyed on one id
                 -- (e.g. imdb) and a *different* id changes on the *arr's side
                 -- (TVDb in particular re-issues ids), the stale value would
@@ -198,6 +217,8 @@ class MediaCache(DatabaseBase):
                 record["tvdb_id"],
                 record["imdb_id"],
                 record.get("musicbrainz_id") or None,
+                record.get("parent_musicbrainz_id") or None,
+                record.get("parent_title") or None,
                 record["folder"],
                 record.get("root_folder") or None,
                 record.get("media_file") or None,

--- a/backend/util/database/plex_cache.py
+++ b/backend/util/database/plex_cache.py
@@ -46,13 +46,15 @@ class PlexCache(DatabaseBase):
         self.execute_query(
             """
             INSERT INTO plex_media_cache
-                (plex_id, instance_name, asset_type, library_name, title, normalized_title, season_number, year, guids, labels, file_paths, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                (plex_id, instance_name, asset_type, library_name, title, normalized_title, parent_title, parent_normalized_title, season_number, year, guids, labels, file_paths, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
             ON CONFLICT(plex_id, instance_name) DO UPDATE SET
                 asset_type = excluded.asset_type,
                 library_name = excluded.library_name,
                 title = excluded.title,
                 normalized_title = excluded.normalized_title,
+                parent_title = excluded.parent_title,
+                parent_normalized_title = excluded.parent_normalized_title,
                 season_number = excluded.season_number,
                 year = excluded.year,
                 guids = excluded.guids,
@@ -67,6 +69,8 @@ class PlexCache(DatabaseBase):
                 item["library_name"],
                 item["title"],
                 item["normalized_title"],
+                item.get("parent_title"),
+                item.get("parent_normalized_title"),
                 item["season_number"],
                 item["year"],
                 json.dumps(item["guids"]),

--- a/backend/util/database/poster_cache.py
+++ b/backend/util/database/poster_cache.py
@@ -119,13 +119,20 @@ class PosterCache(DatabaseBase):
     _UPSERT_SQL = """
             INSERT INTO poster_cache
                 (asset_type, title, normalized_title, year,
-                 tmdb_id, tvdb_id, imdb_id, season_number, folder, file, style,
+                 tmdb_id, tvdb_id, imdb_id,
+                 musicbrainz_id, parent_musicbrainz_id, parent_title,
+                 parent_normalized_title,
+                 season_number, folder, file, style,
                  created_at, priority, image_type, search_only)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(title, year, tmdb_id, tvdb_id, imdb_id, season_number, file)
             DO UPDATE SET
                 asset_type=excluded.asset_type,
                 normalized_title=excluded.normalized_title,
+                musicbrainz_id=excluded.musicbrainz_id,
+                parent_musicbrainz_id=excluded.parent_musicbrainz_id,
+                parent_title=excluded.parent_title,
+                parent_normalized_title=excluded.parent_normalized_title,
                 folder=excluded.folder,
                 style=excluded.style,
                 priority=excluded.priority,
@@ -178,6 +185,10 @@ class PosterCache(DatabaseBase):
             record["tmdb_id"],
             record["tvdb_id"],
             record["imdb_id"],
+            record.get("musicbrainz_id"),
+            record.get("parent_musicbrainz_id"),
+            record.get("parent_title"),
+            record.get("parent_normalized_title"),
             record["season_number"],
             record["folder"],
             record["file"],

--- a/backend/util/database/schema.py
+++ b/backend/util/database/schema.py
@@ -130,6 +130,11 @@ class SchemaManager:
                 ColumnDefinition("library_name", "TEXT"),
                 ColumnDefinition("title", "TEXT"),
                 ColumnDefinition("normalized_title", "TEXT"),
+                # Parent linkage for music albums: the owning artist's title.
+                # NULL for movies/shows/artists. Lets album rows resolve against
+                # the parent-scoped match keys ("{parent_norm}::{album_norm}").
+                ColumnDefinition("parent_title", "TEXT"),
+                ColumnDefinition("parent_normalized_title", "TEXT"),
                 ColumnDefinition("season_number", "INTEGER"),
                 ColumnDefinition("year", "TEXT"),
                 ColumnDefinition("guids", "TEXT"),
@@ -162,6 +167,12 @@ class SchemaManager:
                 ColumnDefinition("tvdb_id", "INTEGER"),
                 ColumnDefinition("imdb_id", "TEXT"),
                 ColumnDefinition("musicbrainz_id", "TEXT"),
+                # Parent linkage for music albums (asset_type="album"): the
+                # owning artist's MusicBrainz ID and title. NULL for every other
+                # asset type. Used to scope album match keys under their artist
+                # so identically-named albums ("Greatest Hits") don't collide.
+                ColumnDefinition("parent_musicbrainz_id", "TEXT"),
+                ColumnDefinition("parent_title", "TEXT"),
                 ColumnDefinition("folder", "TEXT"),
                 ColumnDefinition("root_folder", "TEXT"),
                 ColumnDefinition(

--- a/backend/util/database/schema.py
+++ b/backend/util/database/schema.py
@@ -382,6 +382,14 @@ class SchemaManager:
                 ColumnDefinition("tmdb_id", "INTEGER"),
                 ColumnDefinition("tvdb_id", "INTEGER"),
                 ColumnDefinition("imdb_id", "TEXT"),
+                # MusicBrainz id of a music source poster (artist/album), plus
+                # parent linkage for albums. NULL for non-music posters. Lets a
+                # music cover match its media row by MBID first (is_match /
+                # find_asset_candidate), then by parent-scoped title.
+                ColumnDefinition("musicbrainz_id", "TEXT"),
+                ColumnDefinition("parent_musicbrainz_id", "TEXT"),
+                ColumnDefinition("parent_title", "TEXT"),
+                ColumnDefinition("parent_normalized_title", "TEXT"),
                 ColumnDefinition("season_number", "INTEGER"),
                 ColumnDefinition("folder", "TEXT"),
                 ColumnDefinition("file", "TEXT"),

--- a/backend/util/helper.py
+++ b/backend/util/helper.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 from backend.util.constants import (
     folder_year_regex,
     imdb_id_regex,
+    mbid_id_regex,
     prefixes,
     suffixes,
     tmdb_id_regex,
@@ -368,6 +369,18 @@ def extract_ids(text: str) -> Tuple[Optional[int], Optional[int], Optional[str]]
     imdb = imdb_match.group(1) if imdb_match else None
 
     return tmdb, tvdb, imdb
+
+
+def extract_mbid(text: str) -> Optional[str]:
+    """Extract a MusicBrainz id from text (an ``{mbid-<uuid>}`` style tag).
+
+    Returns the lower-cased canonical UUID, or None. Used to identify custom
+    music art (artist/album) by MusicBrainz id, mirroring extract_ids.
+    """
+    if not text:
+        return None
+    match = mbid_id_regex.search(text)
+    return match.group(1).lower() if match else None
 
 
 def compare_strings(string1: str, string2: str) -> bool:

--- a/backend/util/helper.py
+++ b/backend/util/helper.py
@@ -505,6 +505,18 @@ def is_match(
         except Exception:
             return None
 
+    # MusicBrainz id is the cross-source anchor for music (artists/albums). It
+    # is a GUID string, so it bypasses the integer normalization the other ids
+    # use. When both sides carry one it is authoritative: equal → match,
+    # different → reject (don't fall through to title, which would let two
+    # artists' identically-named albums collide).
+    asset_mbid = (str(asset.get("musicbrainz_id") or "").strip().lower()) or None
+    media_mbid = (str(media.get("musicbrainz_id") or "").strip().lower()) or None
+    if asset_mbid and media_mbid:
+        if asset_mbid == media_mbid:
+            return True, "ID match: musicbrainz_id"
+        return False, ""
+
     shared_id_sources = []
     for key in ["tvdb_id", "tmdb_id", "imdb_id"]:
         asset_id = normalized_id(key, asset)

--- a/backend/util/helper.py
+++ b/backend/util/helper.py
@@ -530,6 +530,25 @@ def is_match(
             return True, "ID match: musicbrainz_id"
         return False, ""
 
+    # Album parent (artist) scoping: when an MBID isn't available on both sides,
+    # title-only matching must not let two artists' identically-titled albums
+    # ("Greatest Hits") cross-match. Both the poster record and the media row
+    # carry the owning artist (parent_normalized_title / parent_title); if both
+    # are known and differ, this is not the same album. When either side lacks a
+    # parent (can't disambiguate), fall through unchanged.
+    def _parent_norm(data: Dict[str, Any]) -> Optional[str]:
+        pnt = data.get("parent_normalized_title")
+        if pnt:
+            return str(pnt).strip().lower() or None
+        pt = data.get("parent_title")
+        return normalize_titles(pt) if pt else None
+
+    asset_parent = _parent_norm(asset)
+    media_parent = _parent_norm(media)
+    parent_mismatch = bool(
+        asset_parent and media_parent and asset_parent != media_parent
+    )
+
     shared_id_sources = []
     for key in ["tvdb_id", "tmdb_id", "imdb_id"]:
         asset_id = normalized_id(key, asset)
@@ -601,7 +620,7 @@ def is_match(
     ]
 
     for condition, reason in match_criteria:
-        if condition and year_matches():
+        if condition and year_matches() and not parent_mismatch:
             return True, reason
     return False, ""
 

--- a/backend/util/plex.py
+++ b/backend/util/plex.py
@@ -699,22 +699,19 @@ class PlexClient:
         self,
         library_name: str,
         item_title: str,
-        poster_path: Optional[str] = None,
+        poster_path: str,
         year: Any = None,
         is_collection: bool = False,
         season_number: Any = None,
         edition: Any = None,
         dry_run: bool = False,
         plex_id: Any = None,
-        url: Optional[str] = None,
     ) -> bool:
         """
         Upload a poster to Plex using plexapi's built-in methods.
         Supports uploading to a series season if season_number is given,
         and targeting a specific movie edition via editionTitle.
         ``plex_id`` (the cached ratingKey) targets the exact item directly.
-        Provide a local ``poster_path`` OR a remote ``url`` (e.g. a Lidarr
-        mediacover URL for the music_art_from_lidarr fallback).
         """
         return self._upload_artwork(
             "uploadPoster",
@@ -722,7 +719,6 @@ class PlexClient:
             library_name,
             item_title,
             filepath=poster_path,
-            url=url,
             year=year,
             is_collection=is_collection,
             season_number=season_number,

--- a/backend/util/plex.py
+++ b/backend/util/plex.py
@@ -337,6 +337,40 @@ class PlexClient:
                                 "file_paths": artist_paths,
                             }
                         )
+                        # Emit a row per album so custom album covers have a
+                        # target. Albums carry their own mbid:// guid; we scope
+                        # them to the parent artist for collision-proof title
+                        # matching. Kept inside the paged walk (one albums() call
+                        # per artist) to bound API cost.
+                        artist_norm = normalize_titles(item.title)
+                        for album in item.albums():
+                            album_guids = {
+                                g.id.split("://")[0]: g.id.split("://")[1]
+                                for g in getattr(album, "guids", [])
+                                if "://" in g.id
+                            }
+                            items.append(
+                                {
+                                    "plex_id": str(album.ratingKey),
+                                    "instance_name": instance_name,
+                                    "asset_type": "album",
+                                    "library_name": library_name,
+                                    "title": album.title,
+                                    "normalized_title": normalize_titles(album.title),
+                                    "parent_title": item.title,
+                                    "parent_normalized_title": artist_norm,
+                                    "season_number": None,
+                                    "year": str(getattr(album, "year", None) or ""),
+                                    "guids": album_guids,
+                                    "labels": [
+                                        label.tag
+                                        for label in getattr(album, "labels", [])
+                                    ],
+                                    "file_paths": list(
+                                        getattr(album, "locations", []) or []
+                                    ),
+                                }
+                            )
                 except Exception as e:
                     logger.error(
                         f"Error processing item '{getattr(item, 'title', '')}': {e}"

--- a/backend/util/plex.py
+++ b/backend/util/plex.py
@@ -699,19 +699,22 @@ class PlexClient:
         self,
         library_name: str,
         item_title: str,
-        poster_path: str,
+        poster_path: Optional[str] = None,
         year: Any = None,
         is_collection: bool = False,
         season_number: Any = None,
         edition: Any = None,
         dry_run: bool = False,
         plex_id: Any = None,
+        url: Optional[str] = None,
     ) -> bool:
         """
         Upload a poster to Plex using plexapi's built-in methods.
         Supports uploading to a series season if season_number is given,
         and targeting a specific movie edition via editionTitle.
         ``plex_id`` (the cached ratingKey) targets the exact item directly.
+        Provide a local ``poster_path`` OR a remote ``url`` (e.g. a Lidarr
+        mediacover URL for the music_art_from_lidarr fallback).
         """
         return self._upload_artwork(
             "uploadPoster",
@@ -719,6 +722,7 @@ class PlexClient:
             library_name,
             item_title,
             filepath=poster_path,
+            url=url,
             year=year,
             is_collection=is_collection,
             season_number=season_number,

--- a/backend/util/plex.py
+++ b/backend/util/plex.py
@@ -818,6 +818,47 @@ class PlexClient:
             plex_id=plex_id,
         )
 
+    def lock_field(
+        self,
+        library_name: str,
+        item_title: str,
+        fields: List[str],
+        *,
+        year: Any = None,
+        season_number: Any = None,
+        dry_run: bool = False,
+        plex_id: Any = None,
+    ) -> bool:
+        """Lock one or more metadata fields (e.g. ``thumb``, ``art``) on a Plex
+        item so a metadata refresh can't overwrite a user-selected image.
+
+        Used for music artists: Plex's music agent otherwise re-derives an
+        artist's image from album art on refresh, reverting a custom poster.
+        Targets the exact item by ``plex_id`` (ratingKey) when available. This
+        edits Plex metadata only — it never touches files.
+        """
+        try:
+            targets = self._locate_targets(
+                library_name,
+                item_title,
+                year=year,
+                season_number=season_number,
+                plex_id=plex_id,
+            )
+            if not targets:
+                return False
+            if not dry_run:
+                edits = {f"{field}.locked": 1 for field in fields}
+                for tgt in targets:
+                    tgt.edit(**edits)
+            return True
+        except Exception as e:
+            self.logger.error(
+                f"Failed to lock {fields} for '{item_title}' in "
+                f"'{library_name}': {e}"
+            )
+            return False
+
     def remove_label(
         self,
         matched_entry: Dict[str, Any],

--- a/backend/util/plex_index.py
+++ b/backend/util/plex_index.py
@@ -130,14 +130,21 @@ class PlexMediaIndex:
                         self._add(self.collections, f"title:{norm_title}", entry)
 
                 elif typ == "artist":
+                    # MBID keys are lower-cased on both build and lookup sides
+                    # (Plex guids can be mixed-case; media_cache/extract_mbid are
+                    # lower) so an MBID match never silently falls back to title.
                     if guids.get("mbid"):
-                        self._add(self.artists, f"mbid:{guids['mbid']}", entry)
+                        self._add(
+                            self.artists, f"mbid:{str(guids['mbid']).lower()}", entry
+                        )
                     if norm_title:
                         self._add(self.artists, f"title:{norm_title}", entry)
 
                 elif typ == "album":
                     if guids.get("mbid"):
-                        self._add(self.albums, f"mbid:{guids['mbid']}", entry)
+                        self._add(
+                            self.albums, f"mbid:{str(guids['mbid']).lower()}", entry
+                        )
                     # Scope the album title under its artist so identically
                     # named albums ("Greatest Hits") across artists don't
                     # collide. Fall back to the bare album title only when the
@@ -228,7 +235,8 @@ class PlexMediaIndex:
             "tmdb": str(asset.get("tmdb_id")) if asset.get("tmdb_id") else None,
             "imdb": asset.get("imdb_id"),
             "tvdb": str(asset.get("tvdb_id")) if asset.get("tvdb_id") else None,
-            "mbid": asset.get("musicbrainz_id") or None,
+            "mbid": (str(asset.get("musicbrainz_id")).lower()
+                     if asset.get("musicbrainz_id") else None),
             "title": title_override or (normalize_titles(title) if title else None),
             # Carried for title-match year-disambiguation (see _match). Inert for
             # guid hits; None when the row has no year, which keeps current

--- a/backend/util/plex_index.py
+++ b/backend/util/plex_index.py
@@ -33,6 +33,10 @@ MOVIE_PRIORITY_KEYS = ["tmdb", "imdb", "title"]
 SHOW_PRIORITY_KEYS = ["tvdb", "tmdb", "imdb", "title"]
 SEASON_PRIORITY_KEYS = ["tvdb", "tmdb", "imdb", "title"]
 COLLECTION_PRIORITY_KEYS = ["title"]
+# Music: MusicBrainz id is the cross-source anchor; fall back to a normalized
+# title (parent-scoped for albums, see _search_values / resolve).
+ARTIST_PRIORITY_KEYS = ["mbid", "title"]
+ALBUM_PRIORITY_KEYS = ["mbid", "title"]
 
 
 def _coerce_year(value: Any) -> Optional[int]:
@@ -71,6 +75,8 @@ class PlexMediaIndex:
         self.shows: Dict[str, List[Dict]] = {}
         self.seasons: Dict[str, List[Dict]] = {}
         self.collections: Dict[str, List[Dict]] = {}
+        self.artists: Dict[str, List[Dict]] = {}
+        self.albums: Dict[str, List[Dict]] = {}
         self._build(media_cache or [])
 
     # ----- build ----------------------------------------------------------
@@ -122,6 +128,29 @@ class PlexMediaIndex:
                 elif typ == "collection":
                     if norm_title:
                         self._add(self.collections, f"title:{norm_title}", entry)
+
+                elif typ == "artist":
+                    if guids.get("mbid"):
+                        self._add(self.artists, f"mbid:{guids['mbid']}", entry)
+                    if norm_title:
+                        self._add(self.artists, f"title:{norm_title}", entry)
+
+                elif typ == "album":
+                    if guids.get("mbid"):
+                        self._add(self.albums, f"mbid:{guids['mbid']}", entry)
+                    # Scope the album title under its artist so identically
+                    # named albums ("Greatest Hits") across artists don't
+                    # collide. Fall back to the bare album title only when the
+                    # parent is unknown.
+                    parent_norm = entry.get("parent_normalized_title")
+                    if norm_title and parent_norm:
+                        self._add(
+                            self.albums,
+                            f"title:{parent_norm}::{norm_title}",
+                            entry,
+                        )
+                    elif norm_title:
+                        self._add(self.albums, f"title:{norm_title}", entry)
             except Exception:
                 # A single malformed row must not abort the whole index build.
                 continue
@@ -199,6 +228,7 @@ class PlexMediaIndex:
             "tmdb": str(asset.get("tmdb_id")) if asset.get("tmdb_id") else None,
             "imdb": asset.get("imdb_id"),
             "tvdb": str(asset.get("tvdb_id")) if asset.get("tvdb_id") else None,
+            "mbid": asset.get("musicbrainz_id") or None,
             "title": title_override or (normalize_titles(title) if title else None),
             # Carried for title-match year-disambiguation (see _match). Inert for
             # guid hits; None when the row has no year, which keeps current
@@ -238,7 +268,24 @@ class PlexMediaIndex:
             return self._match(self.shows, SHOW_PRIORITY_KEYS, values)
         if media_type == "collection":
             return self._match(self.collections, COLLECTION_PRIORITY_KEYS, values)
+        if media_type == "artist":
+            return self._match(self.artists, ARTIST_PRIORITY_KEYS, values)
+        if media_type == "album":
+            # Album titles are matched parent-scoped ("{artist}::{album}") to
+            # avoid cross-artist collisions; MBID (when present) wins first.
+            album_norm = normalize_titles(asset.get("title") or "")
+            parent_norm = normalize_titles(asset.get("parent_title") or "")
+            scoped = f"{parent_norm}::{album_norm}" if parent_norm else album_norm
+            album_values = self._search_values(asset, title_override=scoped)
+            return self._match(self.albums, ALBUM_PRIORITY_KEYS, album_values)
         return [], None
 
     def is_empty(self) -> bool:
-        return not (self.movies or self.shows or self.seasons or self.collections)
+        return not (
+            self.movies
+            or self.shows
+            or self.seasons
+            or self.collections
+            or self.artists
+            or self.albums
+        )

--- a/backend/util/upload_posters.py
+++ b/backend/util/upload_posters.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import shutil
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -214,6 +215,13 @@ class PosterUploader:
                 assets = self._get_assets_from_manifest()
                 upload_results = self._sync_all_assets(
                     assets, plex_client, indexes, self.config.dry_run
+                )
+                # Optional fallback: for music rows with no local custom art,
+                # push the artwork Lidarr already fetched (fanart.tv upstream).
+                upload_results.extend(
+                    self._sync_lidarr_art_fallback(
+                        plex_client, indexes, self.config.dry_run
+                    )
                 )
 
                 return InstanceResult(
@@ -859,6 +867,13 @@ class PosterUploader:
                         dry_run=dry_run,
                         plex_id=entry.get("plex_id"),
                     )
+                # Optional LMA disk sidecars (image-only, refresh-proof).
+                if asset_type in ("artist", "album") and getattr(
+                    self.config, "music_lma_sidecars", False
+                ):
+                    self._write_music_sidecar(
+                        asset_type, poster_path, entry, dry_run
+                    )
                 # Remove overlay label if present (per-library item).
                 if self._has_overlay(entry):
                     plex_client.remove_label(entry, "Overlay", dry_run)
@@ -1156,6 +1171,114 @@ class PosterUploader:
         PlexMediaIndex matcher so poster and asset paths key identically.
         """
         return PlexMediaIndex._match(index, priority_keys, values)
+
+    def _sync_lidarr_art_fallback(
+        self,
+        plex_client: PlexClient,
+        indexes: Tuple[Dict, Dict, Dict, Dict, Dict, Dict],
+        dry_run: bool,
+    ) -> List[UploadResult]:
+        """Push Lidarr-fetched artwork (fanart.tv upstream) for music rows that
+        have NO local custom art. Off unless ``music_art_from_lidarr`` is set.
+
+        Only acts on artist/album rows that are not locally matched (matched=0)
+        and carry a Lidarr ``poster_url``; resolves the Plex target via the same
+        MBID-first index and uploads the remote URL by ratingKey. Local custom
+        art always wins (those rows are matched=1 and handled by the normal
+        path), so this never overrides a user's own poster.
+        """
+        if not getattr(self.config, "music_art_from_lidarr", False):
+            return []
+        _, _, _, _, artist_index, album_index = indexes
+        try:
+            rows = (
+                self.db.media.execute_query(
+                    "SELECT * FROM media_cache "
+                    "WHERE asset_type IN ('artist','album') "
+                    "AND (matched IS NULL OR matched = 0) "
+                    "AND poster_url IS NOT NULL AND poster_url != ''",
+                    fetch_all=True,
+                )
+                or []
+            )
+        except Exception as e:
+            self.logger.warning(f"Lidarr art fallback query failed: {e}")
+            return []
+
+        results: List[UploadResult] = []
+        for row in rows:
+            asset_type = row.get("asset_type")
+            index = artist_index if asset_type == "artist" else album_index
+            if asset_type == "album":
+                parent_norm = normalize_titles(row.get("parent_title") or "")
+                album_norm = normalize_titles(row.get("title") or "")
+                title_key = (
+                    f"{parent_norm}::{album_norm}" if parent_norm else album_norm
+                )
+            else:
+                title_key = normalize_titles(row.get("title") or "")
+            values = {
+                "mbid": row.get("musicbrainz_id") or None,
+                "title": title_key,
+                "year": None,
+            }
+            entries, match_type = self.match_asset(index, ["mbid", "title"], values)
+            if not entries:
+                continue
+            seen_libs = set()
+            for entry in entries:
+                lib = entry.get("library_name")
+                if lib in seen_libs:
+                    continue
+                seen_libs.add(lib)
+                ok = plex_client.upload_poster(
+                    library_name=lib,
+                    item_title=entry.get("title"),
+                    url=row.get("poster_url"),
+                    year=entry.get("year"),
+                    dry_run=dry_run,
+                    plex_id=entry.get("plex_id"),
+                )
+                results.append(
+                    UploadResult(
+                        asset_title=row.get("title", "Unknown"),
+                        asset_type=asset_type,
+                        success=bool(ok),
+                        action="uploaded" if ok else "failed",
+                        reason="Lidarr-fetched art (no local custom art)",
+                        library_name=lib,
+                        match_type=match_type,
+                    )
+                )
+        return results
+
+    def _write_music_sidecar(
+        self, asset_type: str, poster_path: str, entry: Dict, dry_run: bool
+    ) -> None:
+        """Copy a poster/cover into the Plex music library folder as a Local
+        Media Assets sidecar — ``cover.jpg`` for albums, ``artist-poster.jpg``
+        for artists. Writes an image file ONLY (never audio), into a folder that
+        must already exist inside the Plex library. Non-fatal on any error.
+        """
+        try:
+            paths = entry.get("file_paths")
+            if isinstance(paths, str):
+                paths = json.loads(paths or "[]")
+            folders = [p for p in (paths or []) if p and os.path.isdir(p)]
+            if not folders:
+                return
+            name = "cover.jpg" if asset_type == "album" else "artist-poster.jpg"
+            for folder in folders:
+                dest = os.path.join(folder, name)
+                if dry_run:
+                    self.logger.debug(f"[DRY RUN] Would write music sidecar {dest}")
+                    continue
+                shutil.copyfile(poster_path, dest)
+                self.logger.debug(f"[MUSIC_SIDECAR] {dest}")
+        except Exception as e:
+            self.logger.warning(
+                f"Music sidecar write failed for '{entry.get('title')}': {e}"
+            )
 
     @staticmethod
     def _compute_file_hash(poster_path: str, dry_run: bool = False) -> Optional[str]:

--- a/backend/util/upload_posters.py
+++ b/backend/util/upload_posters.py
@@ -250,7 +250,7 @@ class PosterUploader:
 
     def _get_media_indexes(
         self, instance_name: str
-    ) -> Optional[Tuple[Dict, Dict, Dict, Dict]]:
+    ) -> Optional[Tuple[Dict, Dict, Dict, Dict, Dict, Dict]]:
         """Get or build media indexes for an instance"""
         if instance_name in self._media_indexes:
             return self._media_indexes[instance_name]
@@ -295,11 +295,18 @@ class PosterUploader:
         self,
         assets: List[Dict],
         plex_client: PlexClient,
-        indexes: Tuple[Dict, Dict, Dict, Dict],
+        indexes: Tuple[Dict, Dict, Dict, Dict, Dict, Dict],
         dry_run: bool,
     ) -> List[UploadResult]:
         """Sync all assets with consolidated progress reporting"""
-        movie_index, show_index, season_index, collection_index = indexes
+        (
+            movie_index,
+            show_index,
+            season_index,
+            collection_index,
+            artist_index,
+            album_index,
+        ) = indexes
         all_results = []
 
         # Group assets by type for efficient processing
@@ -327,6 +334,16 @@ class PosterUploader:
             for a in assets
             if a.get("asset_type") == "collection" and a.get("matched") == 1
         ]
+        artists = [
+            a
+            for a in assets
+            if a.get("asset_type") == "artist" and a.get("matched") == 1
+        ]
+        albums = [
+            a
+            for a in assets
+            if a.get("asset_type") == "album" and a.get("matched") == 1
+        ]
 
         # Process each type with progress bars
         if movies:
@@ -349,6 +366,16 @@ class PosterUploader:
                 self._sync_collections(
                     collections, plex_client, collection_index, dry_run
                 )
+            )
+
+        if artists:
+            all_results.extend(
+                self._sync_artists(artists, plex_client, artist_index, dry_run)
+            )
+
+        if albums:
+            all_results.extend(
+                self._sync_albums(albums, plex_client, album_index, dry_run)
             )
 
         return all_results
@@ -533,6 +560,104 @@ class PosterUploader:
 
         return results
 
+    def _sync_artists(
+        self,
+        artists: List[Dict],
+        plex_client: PlexClient,
+        artist_index: Dict,
+        dry_run: bool,
+    ) -> List[UploadResult]:
+        """Sync artist posters (music). MusicBrainz id first, then title."""
+        results = []
+
+        with progress(
+            artists,
+            desc="Syncing artist posters",
+            total=len(artists),
+            unit="artist",
+            logger=self.logger,
+        ) as bar:
+            for artist in bar:
+                try:
+                    result = self._sync_single_asset(
+                        asset=artist,
+                        plex_client=plex_client,
+                        index=artist_index,
+                        priority_keys=["mbid", "title"],
+                        dry_run=dry_run,
+                    )
+                    results.append(result)
+                except Exception as e:
+                    self.logger.warning(
+                        f"Error syncing artist '{artist.get('title')}': {e}"
+                    )
+                    results.append(
+                        UploadResult(
+                            asset_title=artist.get("title", "Unknown"),
+                            asset_type="artist",
+                            success=False,
+                            action="failed",
+                            reason=f"Processing error: {e}",
+                        )
+                    )
+
+        return results
+
+    def _sync_albums(
+        self,
+        albums: List[Dict],
+        plex_client: PlexClient,
+        album_index: Dict,
+        dry_run: bool,
+    ) -> List[UploadResult]:
+        """Sync album covers (music). MBID first, else parent-scoped title.
+
+        Album covers are uploaded to the same "poster" slot as everything else
+        (upload_poster targets by ratingKey, type-agnostic). The title key is
+        scoped under the parent artist ("{artist}::{album}") so identically
+        named albums across artists don't collide.
+        """
+        results = []
+
+        with progress(
+            albums,
+            desc="Syncing album covers",
+            total=len(albums),
+            unit="album",
+            logger=self.logger,
+        ) as bar:
+            for album in bar:
+                try:
+                    album_norm = normalize_titles(album.get("title") or "")
+                    parent_norm = normalize_titles(album.get("parent_title") or "")
+                    scoped = (
+                        f"{parent_norm}::{album_norm}" if parent_norm else album_norm
+                    )
+                    result = self._sync_single_asset(
+                        asset=album,
+                        plex_client=plex_client,
+                        index=album_index,
+                        priority_keys=["mbid", "title"],
+                        dry_run=dry_run,
+                        title_override=scoped,
+                    )
+                    results.append(result)
+                except Exception as e:
+                    self.logger.warning(
+                        f"Error syncing album '{album.get('title')}': {e}"
+                    )
+                    results.append(
+                        UploadResult(
+                            asset_title=album.get("title", "Unknown"),
+                            asset_type="album",
+                            success=False,
+                            action="failed",
+                            reason=f"Processing error: {e}",
+                        )
+                    )
+
+        return results
+
     def _sync_single_asset(
         self,
         asset: Dict,
@@ -556,6 +681,7 @@ class PosterUploader:
                 "tmdb": str(asset.get("tmdb_id")) if asset.get("tmdb_id") else None,
                 "imdb": asset.get("imdb_id"),
                 "tvdb": str(asset.get("tvdb_id")) if asset.get("tvdb_id") else None,
+                "mbid": asset.get("musicbrainz_id") or None,
                 "title": title_override or normalize_titles(asset_title),
                 # Year-disambiguates title-only matches so a same-title/different-
                 # year collision can't upload the wrong release (see
@@ -981,18 +1107,27 @@ class PosterUploader:
 
     # Static/utility methods (keeping existing implementations but with improvements)
     @staticmethod
-    def _build_indexes(media_cache: List[Dict]) -> Tuple[Dict, Dict, Dict, Dict]:
+    def _build_indexes(
+        media_cache: List[Dict],
+    ) -> Tuple[Dict, Dict, Dict, Dict, Dict, Dict]:
         """Build the type-separated lookup indexes for fast asset matching.
 
         Thin wrapper over the shared :class:`PlexMediaIndex` (single source of
         truth for the guid-first keying, shared with asset_renamerr's plex
-        apply path). Returns the four raw dicts so the existing _sync_* call
+        apply path). Returns the six raw dicts so the existing _sync_* call
         sites stay unchanged; each key maps to a *list* of entries (the same
         title can live in more than one enabled library on a server, e.g. a
         "Movies" and a "Movies 4K" library — every copy must get the poster).
         """
         idx = PlexMediaIndex(media_cache)
-        return idx.movies, idx.shows, idx.seasons, idx.collections
+        return (
+            idx.movies,
+            idx.shows,
+            idx.seasons,
+            idx.collections,
+            idx.artists,
+            idx.albums,
+        )
 
     @staticmethod
     def match_asset(

--- a/backend/util/upload_posters.py
+++ b/backend/util/upload_posters.py
@@ -844,6 +844,21 @@ class PosterUploader:
                 if not ok:
                     continue
                 uploaded_libs.append(str(entry.get("library_name")))
+                # Artist art reversion hedge: Plex's music agent re-derives an
+                # artist's image from album art on refresh, which would revert a
+                # custom poster. When opted in, lock thumb/art after the upload.
+                # Artist-only (albums are sticky); Plex-metadata only, no files.
+                if asset_type == "artist" and getattr(
+                    self.config, "music_lock_artist_art", False
+                ):
+                    plex_client.lock_field(
+                        library_name=entry["library_name"],
+                        item_title=entry["title"],
+                        fields=["thumb", "art"],
+                        year=entry.get("year"),
+                        dry_run=dry_run,
+                        plex_id=entry.get("plex_id"),
+                    )
                 # Remove overlay label if present (per-library item).
                 if self._has_overlay(entry):
                     plex_client.remove_label(entry, "Overlay", dry_run)

--- a/backend/util/upload_posters.py
+++ b/backend/util/upload_posters.py
@@ -216,13 +216,6 @@ class PosterUploader:
                 upload_results = self._sync_all_assets(
                     assets, plex_client, indexes, self.config.dry_run
                 )
-                # Optional fallback: for music rows with no local custom art,
-                # push the artwork Lidarr already fetched (fanart.tv upstream).
-                upload_results.extend(
-                    self._sync_lidarr_art_fallback(
-                        plex_client, indexes, self.config.dry_run
-                    )
-                )
 
                 return InstanceResult(
                     instance_name=instance_name,
@@ -1175,90 +1168,6 @@ class PosterUploader:
         PlexMediaIndex matcher so poster and asset paths key identically.
         """
         return PlexMediaIndex._match(index, priority_keys, values)
-
-    def _sync_lidarr_art_fallback(
-        self,
-        plex_client: PlexClient,
-        indexes: Tuple[Dict, Dict, Dict, Dict, Dict, Dict],
-        dry_run: bool,
-    ) -> List[UploadResult]:
-        """Push Lidarr-fetched artwork (fanart.tv upstream) for music rows that
-        have NO local custom art. Off unless ``music_art_from_lidarr`` is set.
-
-        Only acts on artist/album rows that are not locally matched (matched=0)
-        and carry a Lidarr ``poster_url``; resolves the Plex target via the same
-        MBID-first index and uploads the remote URL by ratingKey. Local custom
-        art always wins (those rows are matched=1 and handled by the normal
-        path), so this never overrides a user's own poster.
-        """
-        if not getattr(self.config, "music_art_from_lidarr", False):
-            return []
-        _, _, _, _, artist_index, album_index = indexes
-        try:
-            rows = (
-                self.db.media.execute_query(
-                    "SELECT * FROM media_cache "
-                    "WHERE asset_type IN ('artist','album') "
-                    "AND (matched IS NULL OR matched = 0) "
-                    "AND poster_url IS NOT NULL AND poster_url != ''",
-                    fetch_all=True,
-                )
-                or []
-            )
-        except Exception as e:
-            self.logger.warning(f"Lidarr art fallback query failed: {e}")
-            return []
-
-        results: List[UploadResult] = []
-        for row in rows:
-            asset_type = row.get("asset_type")
-            index = artist_index if asset_type == "artist" else album_index
-            if asset_type == "album":
-                parent_norm = normalize_titles(row.get("parent_title") or "")
-                album_norm = normalize_titles(row.get("title") or "")
-                title_key = (
-                    f"{parent_norm}::{album_norm}" if parent_norm else album_norm
-                )
-            else:
-                title_key = normalize_titles(row.get("title") or "")
-            values = {
-                "mbid": (
-                    str(row.get("musicbrainz_id")).lower()
-                    if row.get("musicbrainz_id")
-                    else None
-                ),
-                "title": title_key,
-                "year": None,
-            }
-            entries, match_type = self.match_asset(index, ["mbid", "title"], values)
-            if not entries:
-                continue
-            seen_libs = set()
-            for entry in entries:
-                lib = entry.get("library_name")
-                if lib in seen_libs:
-                    continue
-                seen_libs.add(lib)
-                ok = plex_client.upload_poster(
-                    library_name=lib,
-                    item_title=entry.get("title"),
-                    url=row.get("poster_url"),
-                    year=entry.get("year"),
-                    dry_run=dry_run,
-                    plex_id=entry.get("plex_id"),
-                )
-                results.append(
-                    UploadResult(
-                        asset_title=row.get("title", "Unknown"),
-                        asset_type=asset_type,
-                        success=bool(ok),
-                        action="uploaded" if ok else "failed",
-                        reason="Lidarr-fetched art (no local custom art)",
-                        library_name=lib,
-                        match_type=match_type,
-                    )
-                )
-        return results
 
     def _write_music_sidecar(
         self, asset_type: str, poster_path: str, entry: Dict, dry_run: bool

--- a/backend/util/upload_posters.py
+++ b/backend/util/upload_posters.py
@@ -689,7 +689,11 @@ class PosterUploader:
                 "tmdb": str(asset.get("tmdb_id")) if asset.get("tmdb_id") else None,
                 "imdb": asset.get("imdb_id"),
                 "tvdb": str(asset.get("tvdb_id")) if asset.get("tvdb_id") else None,
-                "mbid": asset.get("musicbrainz_id") or None,
+                "mbid": (
+                    str(asset.get("musicbrainz_id")).lower()
+                    if asset.get("musicbrainz_id")
+                    else None
+                ),
                 "title": title_override or normalize_titles(asset_title),
                 # Year-disambiguates title-only matches so a same-title/different-
                 # year collision can't upload the wrong release (see
@@ -1218,7 +1222,11 @@ class PosterUploader:
             else:
                 title_key = normalize_titles(row.get("title") or "")
             values = {
-                "mbid": row.get("musicbrainz_id") or None,
+                "mbid": (
+                    str(row.get("musicbrainz_id")).lower()
+                    if row.get("musicbrainz_id")
+                    else None
+                ),
                 "title": title_key,
                 "year": None,
             }

--- a/frontend/frontend/package-lock.json
+++ b/frontend/frontend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/frontend/frontend/package-lock.json
+++ b/frontend/frontend/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "frontend",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1028,9 +1028,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1048,9 +1045,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1068,9 +1062,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1088,9 +1079,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1108,9 +1096,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1128,9 +1113,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3909,9 +3891,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3933,9 +3912,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3957,9 +3933,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3981,9 +3954,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1028,6 +1028,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1045,6 +1048,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1062,6 +1068,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1079,6 +1088,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1096,6 +1108,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1113,6 +1128,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3891,6 +3909,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3912,6 +3933,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3933,6 +3957,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3954,6 +3981,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/src/pages/settings/modules/ModuleSettingsPage.jsx
+++ b/frontend/src/pages/settings/modules/ModuleSettingsPage.jsx
@@ -3,6 +3,7 @@ import { configAPI } from '../../../utils/api/config.js';
 import { SETTINGS_MODULES } from '../../../utils/constants/settings_schema.js';
 import { useModuleSchema } from '../../../hooks/useModuleSchema.js';
 import { shouldShowField } from '../../../utils/forms/conditionalFields.js';
+import { useInstancesData } from '../../../hooks/useInstancesData.js';
 import { FieldRegistry } from '../../../components/fields/FieldRegistry.jsx';
 import { Accordion } from '../../../components/ui/Accordion.jsx';
 import { AccordionItem } from '../../../components/ui/AccordionItem.jsx';
@@ -52,6 +53,11 @@ const ModuleSettingsContent = () => {
     const config = useConfig(); // Clean access to configuration data
     const { registerToolbar, clearToolbar } = useToolbar();
     const { schemas: dynamicSchemas } = useModuleSchema();
+    // Instances config (radarr/sonarr/lidarr/plex) for schema conditionals —
+    // e.g. the music fields gated on a Lidarr instance being configured
+    // (condition: service_configured, api_lookup: 'instances').
+    const { instancesData } = useInstancesData();
+    const conditionApiData = useMemo(() => ({ instances: instancesData || {} }), [instancesData]);
 
     // Simplified state management for the UI
     const [expandedModules, setExpandedModules] = useState([]);
@@ -298,7 +304,13 @@ const ModuleSettingsContent = () => {
                                         // current values (e.g. AI Endpoint only shows for the
                                         // providers that use it). Section-scoped data so the
                                         // dependent field name (e.g. ai_provider) resolves.
-                                        .filter(f => shouldShowField(f, formData[module.key] || {}))
+                                        .filter(f =>
+                                            shouldShowField(
+                                                f,
+                                                formData[module.key] || {},
+                                                conditionApiData
+                                            )
+                                        )
                                         .map((field, fieldIndex, visibleFields) => {
                                             try {
                                                 // Section divider: when a field's `section` differs from

--- a/frontend/src/utils/constants/settings_schema.js
+++ b/frontend/src/utils/constants/settings_schema.js
@@ -339,20 +339,6 @@ const CORE_SETTINGS_SCHEMA = [
                     'Folders holding your custom ARTIST/ALBUM art. Files here are recognized as music by folder layout (<Artist>/artist.jpg or poster.jpg, <Artist>/<Album>/cover.jpg) or a flat "Artist.jpg" / "Artist - Album.jpg" name; an {mbid-<id>} tag overrides identity (and works in the regular Source Directories too). Kept separate so a flat "Title.jpg" is never mistaken for a movie poster.',
             },
             {
-                key: 'music_art_from_lidarr',
-                label: 'Fall back to Lidarr-fetched art',
-                type: 'check_box',
-                section: 'Music',
-                conditional: {
-                    field: 'instances',
-                    condition: 'service_configured',
-                    value: 'lidarr',
-                    api_lookup: 'instances',
-                },
-                description:
-                    'When no local/Google Drive custom art matches an artist or album, fall back to the artwork Lidarr already fetched (fanart.tv upstream) via its mediacover URL. Your custom art always takes priority.',
-            },
-            {
                 key: 'music_lock_artist_art',
                 label: 'Lock artist art in Plex',
                 type: 'check_box',

--- a/frontend/src/utils/constants/settings_schema.js
+++ b/frontend/src/utils/constants/settings_schema.js
@@ -325,6 +325,20 @@ const CORE_SETTINGS_SCHEMA = [
             },
             // ─── Music (only shown when a Lidarr instance is configured) ──
             {
+                key: 'music_source_dirs',
+                label: 'Music Art Source Directories',
+                type: 'dirlist_dragdrop',
+                section: 'Music',
+                conditional: {
+                    field: 'instances',
+                    condition: 'service_configured',
+                    value: 'lidarr',
+                    api_lookup: 'instances',
+                },
+                description:
+                    'Folders holding your custom ARTIST/ALBUM art. Files here are recognized as music by folder layout (<Artist>/artist.jpg or poster.jpg, <Artist>/<Album>/cover.jpg) or a flat "Artist.jpg" / "Artist - Album.jpg" name; an {mbid-<id>} tag overrides identity (and works in the regular Source Directories too). Kept separate so a flat "Title.jpg" is never mistaken for a movie poster.',
+            },
+            {
                 key: 'music_art_from_lidarr',
                 label: 'Fall back to Lidarr-fetched art',
                 type: 'check_box',

--- a/frontend/src/utils/constants/settings_schema.js
+++ b/frontend/src/utils/constants/settings_schema.js
@@ -323,6 +323,49 @@ const CORE_SETTINGS_SCHEMA = [
                 description:
                     'Radarr/Sonarr/Lidarr instances supply the media list to match against. Plex instances additionally receive uploaded posters when "Upload posters to this Plex instance" is enabled per-instance.',
             },
+            // ─── Music (only shown when a Lidarr instance is configured) ──
+            {
+                key: 'music_art_from_lidarr',
+                label: 'Fall back to Lidarr-fetched art',
+                type: 'check_box',
+                section: 'Music',
+                conditional: {
+                    field: 'instances',
+                    condition: 'service_configured',
+                    value: 'lidarr',
+                    api_lookup: 'instances',
+                },
+                description:
+                    'When no local/Google Drive custom art matches an artist or album, fall back to the artwork Lidarr already fetched (fanart.tv upstream) via its mediacover URL. Your custom art always takes priority.',
+            },
+            {
+                key: 'music_lock_artist_art',
+                label: 'Lock artist art in Plex',
+                type: 'check_box',
+                section: 'Music',
+                conditional: {
+                    field: 'instances',
+                    condition: 'service_configured',
+                    value: 'lidarr',
+                    api_lookup: 'instances',
+                },
+                description:
+                    "After uploading an artist poster, lock the artist's thumb/art in Plex so the music agent can't re-derive it from album art on the next refresh. Artist-only — album covers are sticky and never need this. Enable only if you see artist posters revert.",
+            },
+            {
+                key: 'music_lma_sidecars',
+                label: 'Write music art sidecars',
+                type: 'check_box',
+                section: 'Music',
+                conditional: {
+                    field: 'instances',
+                    condition: 'service_configured',
+                    value: 'lidarr',
+                    api_lookup: 'instances',
+                },
+                description:
+                    'Also write image-only sidecar files (cover.jpg for albums, artist-poster.jpg / background.jpg for artists) into your Plex music library folders for refresh-proof art. Writes image files only — never touches audio, so seeded music torrents are unaffected. Requires the Local Media Assets agent prioritized in Plex.',
+            },
         ],
     },
 

--- a/frontend/src/utils/forms/conditionalFields.js
+++ b/frontend/src/utils/forms/conditionalFields.js
@@ -37,6 +37,14 @@ const CONDITION_TYPES = {
         selectedValue !== null &&
         selectedValue !== '' &&
         !(Array.isArray(selectedValue) && selectedValue.length === 0),
+    // True when at least one instance of the given service type is configured.
+    // `apiData` is the instances dict (via api_lookup: 'instances'); `value` is
+    // the service type, e.g. 'lidarr'. Used to reveal music-only options only
+    // when a Lidarr instance exists, independent of any selected-instance field.
+    service_configured: (selectedValue, serviceType, apiData) => {
+        const instances = apiData && apiData[serviceType];
+        return Boolean(instances && Object.keys(instances).length > 0);
+    },
 };
 
 /**

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -114,6 +114,34 @@ def test_replace_borders_with_image_composites(tmp_path):
         assert _close(result.getpixel((500, 750)), (255, 0, 0))
 
 
+def test_replace_borders_with_image_square_target(tmp_path):
+    """Album covers are 1:1 — passing target_size=(1000,1000) yields a square
+    output rather than the portrait default."""
+    poster_path = tmp_path / "cover.jpg"
+    Image.new("RGB", (1500, 1500), (0, 255, 0)).save(poster_path, "JPEG")
+    border_path = tmp_path / "border.png"
+    Image.new("RGBA", (1000, 1000), (0, 0, 0, 0)).save(border_path, "PNG")
+
+    out_path = tmp_path / "out.jpg"
+    br = _make_br()
+    assert br.replace_borders_with_image(
+        str(poster_path), str(out_path), str(border_path), (1000, 1000)
+    )
+    with Image.open(out_path) as result:
+        assert result.size == (1000, 1000)
+
+
+def test_remove_borders_square_target(tmp_path):
+    """remove_borders honours a square target_size for album covers."""
+    src = tmp_path / "cover.jpg"
+    Image.new("RGB", (1100, 1100), (10, 20, 30)).save(src, "JPEG")
+    out_path = tmp_path / "out.jpg"
+    br = _make_br()
+    assert br.remove_borders(str(src), str(out_path), 25, (1000, 1000))
+    with Image.open(out_path) as result:
+        assert result.size == (1000, 1000)
+
+
 def test_bundled_borders_dir_exists():
     """Sanity-check that the bundled asset tree shipped with the module."""
     assert _BUNDLED_BORDERS_DIR.is_dir()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,27 @@ def test_asset_renamerr_defaults():
     assert config.notifications.asset_renamerr == {}
 
 
+def test_poster_renamerr_music_defaults():
+    """Music (Lidarr) artwork options default to off / local-only and the
+    config round-trips them."""
+    pr = ChubConfig().poster_renamerr
+    assert pr.music_lock_artist_art is False
+    assert pr.music_lma_sidecars is False
+    assert pr.music_art_from_lidarr is False
+    assert pr.music_art_sources == ["local"]
+
+    loaded = ChubConfig(
+        poster_renamerr={
+            "music_lock_artist_art": True,
+            "music_art_from_lidarr": True,
+            "music_art_sources": ["local", "lidarr"],
+        }
+    )
+    assert loaded.poster_renamerr.music_lock_artist_art is True
+    assert loaded.poster_renamerr.music_art_from_lidarr is True
+    assert loaded.poster_renamerr.music_art_sources == ["local", "lidarr"]
+
+
 def test_asset_renamerr_banner_direct_combo_loads():
     """banner + plex apply must NOT be a hard validation error — the config
     has to stay loadable while a user toggles apply_method (the incompatibility

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,18 +58,17 @@ def test_poster_renamerr_music_defaults():
     pr = ChubConfig().poster_renamerr
     assert pr.music_lock_artist_art is False
     assert pr.music_lma_sidecars is False
-    assert pr.music_art_from_lidarr is False
     assert pr.music_source_dirs == []
 
     loaded = ChubConfig(
         poster_renamerr={
             "music_lock_artist_art": True,
-            "music_art_from_lidarr": True,
+            "music_lma_sidecars": True,
             "music_source_dirs": ["/music/art"],
         }
     )
     assert loaded.poster_renamerr.music_lock_artist_art is True
-    assert loaded.poster_renamerr.music_art_from_lidarr is True
+    assert loaded.poster_renamerr.music_lma_sidecars is True
     assert loaded.poster_renamerr.music_source_dirs == ["/music/art"]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,6 +60,7 @@ def test_poster_renamerr_music_defaults():
     assert pr.music_lma_sidecars is False
     assert pr.music_art_from_lidarr is False
     assert pr.music_art_sources == ["local"]
+    assert pr.music_source_dirs == []
 
     loaded = ChubConfig(
         poster_renamerr={

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,19 +59,18 @@ def test_poster_renamerr_music_defaults():
     assert pr.music_lock_artist_art is False
     assert pr.music_lma_sidecars is False
     assert pr.music_art_from_lidarr is False
-    assert pr.music_art_sources == ["local"]
     assert pr.music_source_dirs == []
 
     loaded = ChubConfig(
         poster_renamerr={
             "music_lock_artist_art": True,
             "music_art_from_lidarr": True,
-            "music_art_sources": ["local", "lidarr"],
+            "music_source_dirs": ["/music/art"],
         }
     )
     assert loaded.poster_renamerr.music_lock_artist_art is True
     assert loaded.poster_renamerr.music_art_from_lidarr is True
-    assert loaded.poster_renamerr.music_art_sources == ["local", "lidarr"]
+    assert loaded.poster_renamerr.music_source_dirs == ["/music/art"]
 
 
 def test_asset_renamerr_banner_direct_combo_loads():

--- a/tests/test_connector_process_arr_media.py
+++ b/tests/test_connector_process_arr_media.py
@@ -159,3 +159,70 @@ def test_genres_and_cast_preserved_per_season(connector):
     s1 = next(r for r in result if r["season_number"] == 1)
     assert s1["genres"] == ["Drama", "Romance"]
     assert s1["cast_data"] == [{"name": "Lead"}]
+
+
+# --- _process_arr_media: artist + album fan-out (music) ---
+
+
+def _artist_with_albums():
+    return [
+        {
+            "title": "REZZ",
+            "musicbrainz_id": "artist-mbid-1",
+            "monitored": True,
+            "genres": ["Electronic"],
+            "seasons": [
+                {
+                    "season_number": 0,
+                    "album_id": 101,
+                    "album_title": "Mass Manipulation",
+                    "foreign_album_id": "album-mbid-1",
+                    "monitored": True,
+                },
+                {
+                    "season_number": 1,
+                    "album_id": 102,
+                    "album_title": "Certain Kind of Magic",
+                    "foreign_album_id": "album-mbid-2",
+                    "monitored": False,
+                },
+            ],
+        }
+    ]
+
+
+def test_artist_fans_out_to_artist_plus_album_rows(connector):
+    """An artist with 2 albums yields the artist row plus 2 asset_type=album
+    rows — albums are first-class, NOT artist+season rows."""
+    result = connector._process_arr_media(_artist_with_albums(), "artist")
+    assert len(result) == 3
+    artist_row = result[0]
+    assert artist_row.get("asset_type") in (None, "artist")
+    assert artist_row["season_number"] is None
+    albums = [r for r in result if r.get("asset_type") == "album"]
+    assert len(albums) == 2
+    for a in albums:
+        assert a["season_number"] is None
+
+
+def test_album_rows_carry_mbid_and_parent_linkage(connector):
+    """Each album row carries its own album MBID and the parent artist's MBID
+    and title, so it can be matched independently and parent-scoped."""
+    result = connector._process_arr_media(_artist_with_albums(), "artist")
+    albums = {r["title"]: r for r in result if r.get("asset_type") == "album"}
+    mass = albums["Mass Manipulation"]
+    assert mass["musicbrainz_id"] == "album-mbid-1"
+    assert mass["parent_musicbrainz_id"] == "artist-mbid-1"
+    assert mass["parent_title"] == "REZZ"
+    assert mass["arr_id"] == 101
+    # Per-album monitored flag is preserved.
+    assert albums["Certain Kind of Magic"]["monitored"] is False
+
+
+def test_artist_without_albums_yields_only_artist_row(connector):
+    """seasons=None (include_episode=False) must not crash and yields just
+    the artist row."""
+    artists = [{"title": "Boards of Canada", "musicbrainz_id": "a", "seasons": None}]
+    result = connector._process_arr_media(artists, "artist")
+    assert len(result) == 1
+    assert result[0]["season_number"] is None

--- a/tests/test_connector_process_arr_media.py
+++ b/tests/test_connector_process_arr_media.py
@@ -226,3 +226,35 @@ def test_artist_without_albums_yields_only_artist_row(connector):
     result = connector._process_arr_media(artists, "artist")
     assert len(result) == 1
     assert result[0]["season_number"] is None
+
+
+def test_album_does_not_inherit_artist_poster_url(connector):
+    """An album with no own cover must get poster_url=None, not the artist's —
+    otherwise the Lidarr-art fallback would push the artist photo as the cover."""
+    artists = [
+        {
+            "title": "REZZ",
+            "musicbrainz_id": "art-1",
+            "poster_url": "http://lidarr/artist.jpg",
+            "seasons": [
+                {
+                    "album_id": 1,
+                    "album_title": "No Cover Album",
+                    "foreign_album_id": "alb-1",
+                    "monitored": True,
+                    # no poster_url for this album
+                },
+                {
+                    "album_id": 2,
+                    "album_title": "Has Cover",
+                    "foreign_album_id": "alb-2",
+                    "monitored": True,
+                    "poster_url": "http://lidarr/album2.jpg",
+                },
+            ],
+        }
+    ]
+    result = connector._process_arr_media(artists, "artist")
+    albums = {r["title"]: r for r in result if r.get("asset_type") == "album"}
+    assert albums["No Cover Album"]["poster_url"] is None
+    assert albums["Has Cover"]["poster_url"] == "http://lidarr/album2.jpg"

--- a/tests/test_connector_process_arr_media.py
+++ b/tests/test_connector_process_arr_media.py
@@ -228,33 +228,3 @@ def test_artist_without_albums_yields_only_artist_row(connector):
     assert result[0]["season_number"] is None
 
 
-def test_album_does_not_inherit_artist_poster_url(connector):
-    """An album with no own cover must get poster_url=None, not the artist's —
-    otherwise the Lidarr-art fallback would push the artist photo as the cover."""
-    artists = [
-        {
-            "title": "REZZ",
-            "musicbrainz_id": "art-1",
-            "poster_url": "http://lidarr/artist.jpg",
-            "seasons": [
-                {
-                    "album_id": 1,
-                    "album_title": "No Cover Album",
-                    "foreign_album_id": "alb-1",
-                    "monitored": True,
-                    # no poster_url for this album
-                },
-                {
-                    "album_id": 2,
-                    "album_title": "Has Cover",
-                    "foreign_album_id": "alb-2",
-                    "monitored": True,
-                    "poster_url": "http://lidarr/album2.jpg",
-                },
-            ],
-        }
-    ]
-    result = connector._process_arr_media(artists, "artist")
-    albums = {r["title"]: r for r in result if r.get("asset_type") == "album"}
-    assert albums["No Cover Album"]["poster_url"] is None
-    assert albums["Has Cover"]["poster_url"] == "http://lidarr/album2.jpg"

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -10,6 +10,7 @@ from backend.util.helper import (
     create_table,
     dict_diff,
     extract_ids,
+    extract_mbid,
     extract_year,
     generate_title_variants,
     get_config_dir,
@@ -84,6 +85,24 @@ def test_extract_ids_imdb_tt_prefix():
 
 def test_extract_ids_returns_none_when_absent():
     assert extract_ids("Just a title") == (None, None, None)
+
+
+# --- extract_mbid ---
+
+
+def test_extract_mbid_tag():
+    mbid = extract_mbid("REZZ {mbid-12345678-1234-1234-1234-123456789abc}")
+    assert mbid == "12345678-1234-1234-1234-123456789abc"
+
+
+def test_extract_mbid_lowercases():
+    mbid = extract_mbid("Artist {mbid-ABCDEF12-3456-7890-ABCD-EF1234567890}")
+    assert mbid == "abcdef12-3456-7890-abcd-ef1234567890"
+
+
+def test_extract_mbid_absent():
+    assert extract_mbid("Inception (2010) {tmdb-27205}") is None
+    assert extract_mbid("") is None
 
 
 # --- is_match: musicbrainz ---

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -135,6 +135,53 @@ def test_is_match_musicbrainz_one_sided_falls_back_to_title():
     assert ok is True
 
 
+def test_is_match_album_same_title_different_artist_rejected():
+    # No MBID on either side; same album title under different artists must NOT
+    # match (parent-scoping gate).
+    ok, _ = is_match(
+        {
+            "title": "Greatest Hits",
+            "normalized_title": "greatesthits",
+            "parent_title": "Queen",
+        },
+        {
+            "title": "Greatest Hits",
+            "normalized_title": "greatesthits",
+            "parent_title": "ABBA",
+        },
+    )
+    assert ok is False
+
+
+def test_is_match_album_same_title_same_artist_matches():
+    ok, _ = is_match(
+        {
+            "title": "Greatest Hits",
+            "normalized_title": "greatesthits",
+            "parent_title": "Queen",
+        },
+        {
+            "title": "Greatest Hits",
+            "normalized_title": "greatesthits",
+            "parent_title": "Queen",
+        },
+    )
+    assert ok is True
+
+
+def test_is_match_album_missing_one_parent_still_matches():
+    # When one side lacks a parent we can't disambiguate — fall through (match).
+    ok, _ = is_match(
+        {"title": "Greatest Hits", "normalized_title": "greatesthits"},
+        {
+            "title": "Greatest Hits",
+            "normalized_title": "greatesthits",
+            "parent_title": "Queen",
+        },
+    )
+    assert ok is True
+
+
 # --- compare_strings ---
 
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -86,6 +86,36 @@ def test_extract_ids_returns_none_when_absent():
     assert extract_ids("Just a title") == (None, None, None)
 
 
+# --- is_match: musicbrainz ---
+
+
+def test_is_match_musicbrainz_id_equal():
+    ok, reason = is_match(
+        {"musicbrainz_id": "abc-123", "title": "Different"},
+        {"musicbrainz_id": "abc-123", "title": "Whatever"},
+    )
+    assert ok and reason == "ID match: musicbrainz_id"
+
+
+def test_is_match_musicbrainz_id_differs_rejects():
+    # Both carry an MBID and they differ → no match, never falls through to a
+    # title heuristic (which would let two artists' albums collide).
+    ok, _ = is_match(
+        {"musicbrainz_id": "abc-123", "title": "Greatest Hits"},
+        {"musicbrainz_id": "xyz-999", "title": "Greatest Hits"},
+    )
+    assert ok is False
+
+
+def test_is_match_musicbrainz_one_sided_falls_back_to_title():
+    # Only one side has an MBID → fall through to title heuristics.
+    ok, _ = is_match(
+        {"title": "REZZ", "normalized_title": "rezz"},
+        {"musicbrainz_id": "abc-123", "title": "REZZ", "normalized_title": "rezz"},
+    )
+    assert ok is True
+
+
 # --- compare_strings ---
 
 

--- a/tests/test_media_cache_upsert.py
+++ b/tests/test_media_cache_upsert.py
@@ -151,3 +151,54 @@ def test_collection_upsert_refreshes_changed_id(db):
         fetch_one=True,
     )
     assert row["tmdb_id"] == 200
+
+
+def test_album_upsert_round_trips_parent_linkage(db):
+    """An album upserts with asset_type='album', its own MusicBrainz id, and
+    the parent artist's MBID/title — keyed parent-scoped so it's distinct from
+    a same-titled album under another artist."""
+    album = {
+        "title": "Greatest Hits",
+        "normalized_title": normalize_titles("Greatest Hits"),
+        "year": None,
+        "musicbrainz_id": "album-mb-1",
+        "parent_musicbrainz_id": "artist-mb-1",
+        "parent_title": "Queen",
+        "alternate_titles": [],
+        "normalized_alternate_titles": [],
+    }
+    db.media.upsert(album, "album", "lidarr", "lidarr_main")
+    row = db.media.execute_query(
+        "SELECT asset_type, musicbrainz_id, parent_musicbrainz_id, parent_title "
+        "FROM media_cache WHERE musicbrainz_id='album-mb-1'",
+        fetch_one=True,
+    )
+    assert row["asset_type"] == "album"
+    assert row["parent_musicbrainz_id"] == "artist-mb-1"
+    assert row["parent_title"] == "Queen"
+
+
+def test_album_identity_is_parent_scoped(db):
+    """Two artists' identically-titled, MBID-less albums must NOT collide into
+    one row (distinct identity via parent scoping)."""
+    base = {
+        "year": None,
+        "alternate_titles": [],
+        "normalized_alternate_titles": [],
+        "title": "Greatest Hits",
+        "normalized_title": normalize_titles("Greatest Hits"),
+        "musicbrainz_id": None,
+    }
+    db.media.upsert(
+        {**base, "parent_title": "Queen", "parent_musicbrainz_id": "q"},
+        "album", "lidarr", "lidarr_main",
+    )
+    db.media.upsert(
+        {**base, "parent_title": "ABBA", "parent_musicbrainz_id": "a"},
+        "album", "lidarr", "lidarr_main",
+    )
+    row = db.media.execute_query(
+        "SELECT COUNT(*) AS n FROM media_cache WHERE asset_type='album'",
+        fetch_one=True,
+    )
+    assert row["n"] == 2

--- a/tests/test_plex_index.py
+++ b/tests/test_plex_index.py
@@ -116,3 +116,94 @@ def test_malformed_row_does_not_abort_build():
 def test_is_empty():
     assert PlexMediaIndex([]).is_empty()
     assert not PlexMediaIndex([_movie(1, "Movies", tmdb="42")]).is_empty()
+
+
+# --- music: artists + albums ---
+
+
+def _artist(plex_id, lib, *, mbid=None, title="REZZ", norm="rezz"):
+    guids = {"mbid": mbid} if mbid else {}
+    return {
+        "plex_id": plex_id,
+        "instance_name": "plex1",
+        "asset_type": "artist",
+        "library_name": lib,
+        "title": title,
+        "normalized_title": norm,
+        "season_number": None,
+        "guids": guids,
+    }
+
+
+def _album(plex_id, lib, *, mbid=None, title="Hits", norm="hits", parent="REZZ"):
+    guids = {"mbid": mbid} if mbid else {}
+    from backend.util.normalization import normalize_titles
+
+    return {
+        "plex_id": plex_id,
+        "instance_name": "plex1",
+        "asset_type": "album",
+        "library_name": lib,
+        "title": title,
+        "normalized_title": norm,
+        "parent_title": parent,
+        "parent_normalized_title": normalize_titles(parent),
+        "season_number": None,
+        "guids": guids,
+    }
+
+
+def test_artist_resolves_by_mbid_first():
+    idx = PlexMediaIndex([_artist(1, "Music", mbid="art-1")])
+    entries, key = idx.resolve(
+        {"musicbrainz_id": "art-1", "title": "Wrong"}, media_type="artist"
+    )
+    assert key == "MBID" and [e["plex_id"] for e in entries] == [1]
+
+
+def test_artist_title_fallback():
+    idx = PlexMediaIndex([_artist(1, "Music", title="REZZ", norm="rezz")])
+    entries, key = idx.resolve({"title": "REZZ"}, media_type="artist")
+    assert key == "TITLE" and [e["plex_id"] for e in entries] == [1]
+
+
+def test_album_resolves_by_mbid_first():
+    idx = PlexMediaIndex([_album(5, "Music", mbid="alb-1")])
+    entries, key = idx.resolve(
+        {"musicbrainz_id": "alb-1", "title": "x", "parent_title": "y"},
+        media_type="album",
+    )
+    assert key == "MBID" and [e["plex_id"] for e in entries] == [5]
+
+
+def test_album_title_is_parent_scoped_no_cross_artist_collision():
+    # Two artists both have a "Greatest Hits" album with no MBID — a bare title
+    # match would collide; parent-scoping keeps them distinct.
+    idx = PlexMediaIndex(
+        [
+            _album(1, "Music", title="Greatest Hits", norm="greatesthits",
+                   parent="Queen"),
+            _album(2, "Music", title="Greatest Hits", norm="greatesthits",
+                   parent="ABBA"),
+        ]
+    )
+    entries, key = idx.resolve(
+        {"title": "Greatest Hits", "parent_title": "Queen"}, media_type="album"
+    )
+    assert key == "TITLE"
+    assert [e["plex_id"] for e in entries] == [1]
+
+
+def test_album_type_separation_from_artist():
+    idx = PlexMediaIndex([_artist(1, "Music", mbid="shared")])
+    # An album lookup against an index holding only an artist resolves nothing
+    # even on a shared id value.
+    entries, key = idx.resolve(
+        {"musicbrainz_id": "shared", "title": "x"}, media_type="album"
+    )
+    assert entries == [] and key is None
+
+
+def test_is_empty_includes_music():
+    assert not PlexMediaIndex([_artist(1, "Music", mbid="a")]).is_empty()
+    assert not PlexMediaIndex([_album(1, "Music", mbid="a")]).is_empty()

--- a/tests/test_plex_index.py
+++ b/tests/test_plex_index.py
@@ -207,3 +207,23 @@ def test_album_type_separation_from_artist():
 def test_is_empty_includes_music():
     assert not PlexMediaIndex([_artist(1, "Music", mbid="a")]).is_empty()
     assert not PlexMediaIndex([_album(1, "Music", mbid="a")]).is_empty()
+
+
+def test_artist_mbid_match_is_case_insensitive():
+    # Plex guid may be mixed-case; the asset MBID (from extract_mbid / Lidarr)
+    # is lower-case. The index must still match.
+    idx = PlexMediaIndex([_artist(1, "Music", mbid="ABCDEF12-3456-7890-ABCD-EF1234567890")])
+    entries, key = idx.resolve(
+        {"musicbrainz_id": "abcdef12-3456-7890-abcd-ef1234567890"},
+        media_type="artist",
+    )
+    assert key == "MBID" and [e["plex_id"] for e in entries] == [1]
+
+
+def test_album_mbid_match_is_case_insensitive():
+    idx = PlexMediaIndex([_album(1, "Music", mbid="AAAA1111-2222-3333-4444-555566667777")])
+    entries, key = idx.resolve(
+        {"musicbrainz_id": "aaaa1111-2222-3333-4444-555566667777", "title": "x"},
+        media_type="album",
+    )
+    assert key == "MBID" and [e["plex_id"] for e in entries] == [1]

--- a/tests/test_poster_renamerr.py
+++ b/tests/test_poster_renamerr.py
@@ -791,3 +791,64 @@ def test_match_item_skips_unchanged_write(tmp_path):
         assert media_row()["matched"] == 0
     finally:
         db.__exit__(None, None, None)
+
+
+# --- build_asset_record: music classification (Phase 4 sourcing) ---
+
+
+def test_build_asset_record_music_folder_artist():
+    from backend.modules.poster_renamerr import build_asset_record
+
+    r = build_asset_record("artist.jpg", "/music/REZZ", music_root="/music")
+    assert r["music_kind"] == "artist"
+    assert r["title"] == "REZZ"
+    assert r["parent_title"] is None
+
+
+def test_build_asset_record_music_folder_album():
+    from backend.modules.poster_renamerr import build_asset_record
+
+    r = build_asset_record(
+        "cover.jpg", "/music/REZZ/Mass Manipulation", music_root="/music"
+    )
+    assert r["music_kind"] == "album"
+    assert r["title"] == "Mass Manipulation"
+    assert r["parent_title"] == "REZZ"
+
+
+def test_build_asset_record_music_flat_album():
+    from backend.modules.poster_renamerr import build_asset_record
+
+    r = build_asset_record(
+        "Boards of Canada - Geogaddi.jpg", "/music", music_root="/music"
+    )
+    assert r["music_kind"] == "album"
+    assert r["title"] == "Geogaddi"
+    assert r["parent_title"] == "Boards of Canada"
+
+
+def test_build_asset_record_mbid_tag_in_normal_dir():
+    """An {mbid-} tag marks a file as music even outside a music source dir."""
+    from backend.modules.poster_renamerr import build_asset_record
+
+    r = build_asset_record(
+        "REZZ {mbid-12345678-1234-1234-1234-123456789abc}.jpg", "/posters"
+    )
+    assert r["music_kind"] == "artist"
+    assert r["title"] == "REZZ"
+    assert r["musicbrainz_id"] == "12345678-1234-1234-1234-123456789abc"
+
+
+def test_build_asset_record_movie_unaffected():
+    """Non-music files keep the movie/show path (no music_kind)."""
+    from backend.modules.poster_renamerr import build_asset_record
+
+    r = build_asset_record("Inception (2010) {tmdb-27205}.jpg", "/posters")
+    assert r.get("music_kind") is None
+    assert r["tmdb_id"] == 27205
+
+
+def test_classify_asset_record_honors_music_kind():
+    m = make_module()
+    assert m._classify_asset_record({"music_kind": "album"}, set()) == "album"
+    assert m._classify_asset_record({"music_kind": "artist"}, set()) == "artist"

--- a/tests/test_upload_posters.py
+++ b/tests/test_upload_posters.py
@@ -18,11 +18,14 @@ def test_build_indexes_movie_by_title_and_guids():
             "guids": {"tmdb": "27205", "imdb": "tt1375666"},
         }
     ]
-    movie_idx, show_idx, season_idx, coll_idx = PosterUploader._build_indexes(cache)
+    movie_idx, show_idx, season_idx, coll_idx, artist_idx, album_idx = (
+        PosterUploader._build_indexes(cache)
+    )
     assert "title:inception" in movie_idx
     assert "tmdb:27205" in movie_idx
     assert "imdb:tt1375666" in movie_idx
     assert show_idx == {} and season_idx == {} and coll_idx == {}
+    assert artist_idx == {} and album_idx == {}
 
 
 def test_build_indexes_show_with_no_season_indexed_as_show():
@@ -34,7 +37,7 @@ def test_build_indexes_show_with_no_season_indexed_as_show():
             "guids": {"tvdb": "999"},
         }
     ]
-    _, show_idx, season_idx, _ = PosterUploader._build_indexes(cache)
+    _, show_idx, season_idx, *_ = PosterUploader._build_indexes(cache)
     assert "title:showname" in show_idx
     assert "tvdb:999" in show_idx
     assert season_idx == {}
@@ -49,7 +52,7 @@ def test_build_indexes_season_indexed_separately():
             "guids": {"tvdb": "999"},
         }
     ]
-    _, show_idx, season_idx, _ = PosterUploader._build_indexes(cache)
+    _, show_idx, season_idx, *_ = PosterUploader._build_indexes(cache)
     assert show_idx == {}
     assert "title:showname:S2" in season_idx
     assert "tvdb:999:S2" in season_idx
@@ -57,7 +60,7 @@ def test_build_indexes_season_indexed_separately():
 
 def test_build_indexes_collection():
     cache = [{"asset_type": "collection", "normalized_title": "marvelcinematic"}]
-    _, _, _, coll_idx = PosterUploader._build_indexes(cache)
+    _, _, _, coll_idx, _, _ = PosterUploader._build_indexes(cache)
     assert "title:marvelcinematic" in coll_idx
 
 


### PR DESCRIPTION
## What & why

CHUB already had a full Lidarr data foundation but excluded it from everything artwork-related. This brings **custom artist posters and album covers all the way to Plex (and therefore Plexamp, which renders Plex's selected art)**, plus closes the renameinatorr parity gap — all without ever touching audio files, so seeded music torrents are never endangered.

## Seeding-safety invariant
The artwork pipeline only ever writes **image files**: default delivery is push-to-Plex by ratingKey (zero disk writes); the optional LMA sidecars only *add* `cover.jpg`/`artist-poster.jpg`. It never retags, renames, moves, or deletes audio and never changes `NamingConfig`/`MediaManagementConfig`. `renameinatorr` renames the *library* copy via Lidarr's own hardlink-safe `RenameFiles` (content/tags untouched), at byte-for-byte parity with Radarr/Sonarr.

## What's included
- **Maintenance parity** — `renameinatorr` now loops Lidarr (its loop is app-agnostic); new `LidarrClient.get_rename_list` / `rename_media` (per-artist `RenameFiles` with trackfile IDs derived from the preview) / `rename_folders` (`artist/editor`). All four Lidarr endpoints verified against Lidarr's v1 source.
- **Albums as first-class cache rows** — `connector._process_arr_media` emits `asset_type="album"` rows keyed by the album MusicBrainz id with parent-artist linkage (replacing dormant artist+positional-season rows). Plex `get_all_plex_media` enumerates `item.albums()`. New nullable `parent_*` columns auto-migrate. **upgradinatorr is untouched** (it still reads `normalize_arr_media`'s seasons list).
- **Matching + upload** — `PlexMediaIndex` gains MBID-first artist/album indexes with parent-scoped album titles (no "Greatest Hits" cross-artist collisions); MBID keys are case-folded on both index and lookup sides; `is_match`/`find_asset_candidate`/`poster_cache` are MBID-aware and parent-scoped for albums; `upload_posters` gains `_sync_artists`/`_sync_albums` (Plex-direct by ratingKey).
- **Sourcing (custom art)** — `music_source_dirs` config; the scanner recognizes music by folder layout (`<Artist>/artist.jpg`, `<Artist>/<Album>/cover.jpg`), flat `Artist - Album.jpg`, or an `{mbid-}` tag (honored anywhere). Movie/TV scanning is byte-identical.
- **Backgrounds/logos** — `asset_renamerr` processes music artist (background+logo) / album (background) via its existing `local` + `fanart.tv` sources; album logo skipped (no provider logos).
- **Square borders** — `border_replacerr` renders album covers 1000×1000; artist/poster stays portrait.
- **Options (default off)** — `music_lock_artist_art` (locks Plex `thumb`/`art` after an artist upload to defeat the music agent's reversion), `music_lma_sidecars` (image-only disk sidecars).
- **Frontend** — new `service_configured` condition; a gated **Music** section on Poster Renamerr visible only when a Lidarr instance is configured.

## Not included / deferred
- **No Lidarr-fetched-art fallback.** An earlier revision had a `music_art_from_lidarr` fallback (push Lidarr's own art when no custom art matched). It was dropped: Lidarr just re-serves upstream art — album covers come from the Cover Art Archive (MusicBrainz's image store, which Plex already fetches) and artist backgrounds/logos come from fanart.tv (already a first-class `asset_renamerr` source). So it was redundant for real surface area.
- **`health_checkarr` and `nohl`** Lidarr support are intentionally **not** here — both delete media and need verified Lidarr health-message formats / a careful music file scanner, so they warrant their own focused PR. (`LidarrClient.delete_track_file` is landed now, ready for it.)

## Verification
- Backend: `ruff check .` clean; **933 pytest** pass (auth test skipped — unrelated local crypto env issue). New tests cover album modeling/parent linkage, MBID-first match keys + parent-scoped collisions (reject/accept/one-sided), case-insensitive MBID matching, the music scanner conventions, square borders, `extract_mbid`, and config defaults.
- Frontend: `npm run lint` and `prettier --check src` clean; music fields hidden with no Lidarr instance, visible with one.

## Manual checks recommended before merge
Artist poster, artist background/logo, album cover, album background in Plex web **and** Plexamp; the artist-poster reversion check with `music_lock_artist_art` off then on; and confirm a seeded album torrent stays 100% after a music-art run.

https://claude.ai/code/session_01JFfSKekJJQ6KoeURN14nvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFfSKekJJQ6KoeURN14nvJ)_