### PR TITLE
Poster Cleanarr stale-duplicate matching + overlays toggle + per-schedule-block overrides

### DIFF
--- a/backend/api/posters.py
+++ b/backend/api/posters.py
@@ -40,15 +40,19 @@ def get_cleanarr_logger(request: Request) -> Any:
     return get_module_logger(request, "poster_cleanarr")
 
 
-def _stale_rating_key_map(db: "ChubDB", ids: list) -> dict:
-    """Map ('tvdb'|'tmdb', id) -> Plex rating_key (int) via
-    media_cache.plex_mapping_id -> plex_media_cache.plex_id. Missing mappings
-    are simply absent from the result."""
+def _stale_plex_match_map(db: "ChubDB", ids: list) -> dict:
+    """Map ('tvdb'|'tmdb', id) -> {rating_key, title, year} for live media, via
+    media_cache.plex_mapping_id -> plex_media_cache. The Plex title+year let the
+    UI attach a stale folder to its poster row even when the cached rating_key
+    has drifted from Plex's live metadata (a re-add / re-match mints a new key,
+    so the cached plex_id no longer matches the on-disk bundle). Missing
+    mappings are simply absent from the result."""
     out: dict = {}
     if not ids:
         return out
     rows = db.media.execute_query(
-        "SELECT m.tvdb_id AS tvdb_id, m.tmdb_id AS tmdb_id, p.plex_id AS plex_id "
+        "SELECT m.tvdb_id AS tvdb_id, m.tmdb_id AS tmdb_id, "
+        "p.plex_id AS plex_id, p.title AS title, p.year AS year "
         "FROM media_cache m JOIN plex_media_cache p ON m.plex_mapping_id = p.id "
         "WHERE m.plex_mapping_id IS NOT NULL",
         fetch_all=True,
@@ -58,14 +62,25 @@ def _stale_rating_key_map(db: "ChubDB", ids: list) -> dict:
         try:
             pid = int(r["plex_id"])
         except (ValueError, TypeError, KeyError):
-            continue
+            pid = None  # keep the title/year so the UI can still match by name
         for kind, raw in (("tvdb", r.get("tvdb_id")), ("tmdb", r.get("tmdb_id"))):
             try:
                 key = (kind, int(raw)) if raw not in (None, "", 0) else None
             except (ValueError, TypeError):
                 key = None
             if key in wanted:
-                out[key] = pid
+                # plex_media_cache.year is TEXT; coerce to int so it lines up
+                # with the bundle scan's integer year for the UI match.
+                year_raw = r.get("year")
+                try:
+                    year_val = int(year_raw) if year_raw not in (None, "") else None
+                except (ValueError, TypeError):
+                    year_val = None
+                out[key] = {
+                    "rating_key": pid,
+                    "title": r.get("title") or "",
+                    "year": year_val,
+                }
     return out
 
 
@@ -3023,6 +3038,9 @@ def _build_cleanup_overrides(body: dict) -> dict:
     asset_dirs = body.get("asset_dirs")
     if isinstance(asset_dirs, list):
         overrides["asset_dirs"] = [str(p) for p in asset_dirs]
+
+    if "overlays_only" in body:
+        overrides["overlays_only"] = bool(body.get("overlays_only"))
     return overrides
 
 
@@ -3258,10 +3276,12 @@ async def scan_kometa_assets(
 
         canonical = ca._build_canonical_folder_map(db, instances)
         stale_raw = ca._scan_stale_duplicates(asset_dirs, canonical)
-        rk = _stale_rating_key_map(db, [d["id"] for d in stale_raw])
+        match = _stale_plex_match_map(db, [d["id"] for d in stale_raw])
         stale = [
             {
-                "rating_key": rk.get(d["id"]),
+                "rating_key": (match.get(d["id"]) or {}).get("rating_key"),
+                "plex_title": (match.get(d["id"]) or {}).get("title", ""),
+                "plex_year": (match.get(d["id"]) or {}).get("year"),
                 "name": d["name"],
                 "canonical": d["canonical"],
                 "canonical_present": d["canonical_present"],

--- a/backend/api/schedule.py
+++ b/backend/api/schedule.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from backend.api.utils import error, get_logger, ok
 from backend.modules import MODULES
-from backend.util.config import ChubConfig, load_config, save_config
+from backend.util.config import ChubConfig, ScheduleBlock, load_config, save_config
 from backend.util.scheduler import (
     _profile_value,
     _upgradinatorr_profile_label,
@@ -34,6 +34,22 @@ class ScheduleUpdateRequest(BaseModel):
 
     module: str
     schedule: str
+
+
+class ScheduleBlockInput(BaseModel):
+    """One multi-block schedule entry from the editor."""
+
+    label: str = ""
+    enabled: bool = True
+    schedule: str = ""
+    overrides: dict = {}
+
+
+class ScheduleBlocksUpdateRequest(BaseModel):
+    """Replace the full set of multi-block schedules for one module."""
+
+    module: str
+    blocks: list[ScheduleBlockInput] = []
 
 
 def get_config() -> ChubConfig:
@@ -112,12 +128,49 @@ async def get_all_schedules(
                 }
             )
 
+        # Multi-block schedules (config.schedule_blocks): module -> [blocks].
+        # Each enabled block is also surfaced in sub_schedules so the dashboard
+        # Upcoming list + cron next-run cover it; the raw blocks are returned
+        # under schedule_blocks for the editor.
+        schedule_blocks: dict[str, list[dict[str, Any]]] = {}
+        blocks_by_module = getattr(config, "schedule_blocks", None) or {}
+        for module_name, blocks in blocks_by_module.items():
+            out_blocks: list[dict[str, Any]] = []
+            for index, block in enumerate(blocks or []):
+                sched = (_profile_value(block, "schedule", "") or "").strip()
+                label = _profile_value(block, "label", "") or f"block {index + 1}"
+                enabled = bool(_profile_value(block, "enabled", True))
+                overrides = _profile_value(block, "overrides", {}) or {}
+                nr = cron_next_run(sched) if sched else None
+                next_run = nr.isoformat() if nr is not None else None
+                out_blocks.append(
+                    {
+                        "label": label,
+                        "enabled": enabled,
+                        "schedule": sched,
+                        "overrides": overrides,
+                        "next_run": next_run,
+                    }
+                )
+                if sched and enabled:
+                    sub_schedules.append(
+                        {
+                            "module": module_name,
+                            "label": label,
+                            "schedule": sched,
+                            "enabled": enabled,
+                            "next_run": next_run,
+                        }
+                    )
+            schedule_blocks[module_name] = out_blocks
+
         return ok(
             "Schedules retrieved successfully",
             {
                 "schedule": schedule_data,
                 "next_runs": next_runs,
                 "sub_schedules": sub_schedules,
+                "schedule_blocks": schedule_blocks,
             },
         )
 
@@ -265,6 +318,67 @@ async def update_module_schedule(
         return error(
             f"Failed to update schedule: {str(e)}",
             code="SCHEDULE_UPDATE_ERROR",
+            status_code=500,
+        )
+
+
+@router.post(
+    "/schedule/blocks",
+    summary="Replace a module's multi-block schedules",
+    description=(
+        "Set the full list of schedule blocks for a module. Each block has its "
+        "own schedule string and an overrides map applied only to that run, so "
+        "one module can e.g. report daily and remove weekly."
+    ),
+)
+async def update_module_schedule_blocks(
+    data: ScheduleBlocksUpdateRequest, logger: Any = Depends(get_logger)
+) -> JSONResponse:
+    """Replace config.schedule_blocks[module] with the supplied blocks."""
+    try:
+        module_name = data.module
+        if module_name not in MODULES:
+            available_modules = ", ".join(sorted(MODULES.keys()))
+            return error(
+                f"Invalid module name: '{module_name}'. "
+                f"Available modules: {available_modules}",
+                code="INVALID_MODULE_NAME",
+                status_code=400,
+            )
+
+        config = load_config()
+        blocks = [
+            ScheduleBlock(
+                label=b.label,
+                enabled=b.enabled,
+                schedule=b.schedule,
+                overrides=b.overrides or {},
+            )
+            for b in data.blocks
+        ]
+        if blocks:
+            config.schedule_blocks[module_name] = blocks
+        else:
+            # Empty list clears the module's blocks rather than persisting [].
+            config.schedule_blocks.pop(module_name, None)
+
+        save_config(config)
+        logger.info(
+            f"Updated {len(blocks)} schedule block(s) for module: {module_name}"
+        )
+        return ok(
+            f"Schedule blocks for '{module_name}' updated successfully",
+            {
+                "module": module_name,
+                "blocks": [b.model_dump() for b in blocks],
+            },
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to update schedule blocks for module {data.module}: {e}")
+        return error(
+            f"Failed to update schedule blocks: {str(e)}",
+            code="SCHEDULE_BLOCKS_UPDATE_ERROR",
             status_code=500,
         )
 

--- a/backend/util/config.py
+++ b/backend/util/config.py
@@ -694,8 +694,25 @@ class ConfigNotifications(BaseModel):
 # ==== ROOT CONFIG MODEL ====
 
 
+class ScheduleBlock(BaseModel):
+    """One entry in a module's multi-block schedule. Each block fires on its own
+    `schedule` string and injects `overrides` into that scheduled run's config,
+    so a single module can e.g. report daily and remove weekly. Overrides reuse
+    the same job-payload mechanism as Upgradinatorr's per-profile schedules."""
+
+    label: str = ""
+    enabled: bool = True
+    schedule: str = ""
+    overrides: Dict[str, Any] = Field(default_factory=dict)
+
+
 class ChubConfig(BaseModel):
     schedule: Dict[str, Any] = Field(default_factory=dict)
+    # Optional multi-block schedules keyed by module name. Additive to
+    # `schedule` above (the single-string-per-module form, untouched); a module
+    # may use either or both. Each block carries its own override set (e.g.
+    # {"mode": "remove"}) applied only to that scheduled run.
+    schedule_blocks: Dict[str, List[ScheduleBlock]] = Field(default_factory=dict)
     instances: InstancesConfig = Field(default_factory=InstancesConfig)
     notifications: ConfigNotifications = Field(default_factory=ConfigNotifications)
     sync_gdrive: SyncGDriveConfig = Field(default_factory=SyncGDriveConfig)

--- a/backend/util/scheduler.py
+++ b/backend/util/scheduler.py
@@ -356,6 +356,7 @@ class ChubScheduler:
                         queued_modules.add(name)
 
             self._tick_upgradinatorr_profiles(queued_modules)
+            self._tick_schedule_blocks(queued_modules)
 
         except Exception as e:
             if self.logger:
@@ -425,6 +426,78 @@ class ChubScheduler:
                 print(
                     f"[SCHEDULER] Failed to queue Upgradinatorr profiles: {result['message']}"
                 )
+
+    def _tick_schedule_blocks(self, queued_modules: set) -> None:
+        """Queue module runs from multi-block schedules (config.schedule_blocks).
+
+        Each block fires on its own schedule string and injects its `overrides`
+        into the run (e.g. one block reports daily, another removes weekly).
+        Blocks for a module already queued this tick — or already running — are
+        skipped; if several blocks for one module are due at the same minute,
+        their overrides are merged (later blocks win). The per-block schedule
+        key keeps each block's cron next-run cache independent.
+        """
+        blocks_by_module = getattr(self.config, "schedule_blocks", None) or {}
+        if not blocks_by_module:
+            return
+
+        log_adapter = self.logger.get_adapter("scheduler") if self.logger else None
+
+        for module_name, blocks in blocks_by_module.items():
+            if module_name in queued_modules or not blocks:
+                continue
+
+            status = self.module_orchestrator.get_module_status(module_name)
+            if status["running"]:
+                continue
+
+            merged_overrides: Dict[str, Any] = {}
+            due_labels: List[str] = []
+            for index, block in enumerate(blocks):
+                if not _profile_value(block, "enabled", True):
+                    continue
+                sched = _profile_value(block, "schedule", "")
+                if not sched:
+                    continue
+                label = _profile_value(block, "label", "") or f"block {index + 1}"
+                schedule_key = f"{module_name}:block:{index}:{label}"
+                if check_schedule(schedule_key, sched, log_adapter):
+                    overrides = _profile_value(block, "overrides", {}) or {}
+                    if isinstance(overrides, dict):
+                        merged_overrides.update(overrides)
+                    due_labels.append(label)
+
+            if not due_labels:
+                continue
+
+            if self.logger:
+                self.logger.get_adapter("SCHEDULER").info(
+                    f"Running scheduled {module_name} block(s): "
+                    + ", ".join(due_labels)
+                )
+            else:
+                print(
+                    f"[SCHEDULER] Running scheduled {module_name} block(s): "
+                    + ", ".join(due_labels)
+                )
+
+            result = self.module_orchestrator.run_module_async(
+                module_name,
+                f"scheduled:blocks:{','.join(due_labels)}",
+                overrides=merged_overrides or None,
+            )
+            if not result["success"]:
+                if self.logger:
+                    self.logger.get_adapter("SCHEDULER").error(
+                        f"Failed to queue {module_name} blocks: {result['message']}"
+                    )
+                else:
+                    print(
+                        f"[SCHEDULER] Failed to queue {module_name} blocks: "
+                        f"{result['message']}"
+                    )
+                continue
+            queued_modules.add(module_name)
 
     def _system_tick(self) -> None:
         """

--- a/frontend/src/components/modules/ScheduleBlocksEditor.jsx
+++ b/frontend/src/components/modules/ScheduleBlocksEditor.jsx
@@ -1,0 +1,163 @@
+import React, { useCallback } from 'react';
+import { ScheduleField } from '../fields/custom/ScheduleField';
+import { Button } from '../ui';
+
+// Editor for a module's multi-block schedules. Each block fires on its own
+// schedule and applies its own overrides to that run (e.g. a daily "report"
+// block plus a weekly "remove" block). `mode` is broken out as a dropdown
+// since it's the primary override; everything else lives in an advanced JSON
+// field. Blocks run alongside the module's single top-level schedule.
+
+// Mode values shared by the cleanup-style modules. Other modules ignore an
+// unknown mode, so offering the superset is harmless.
+const MODE_OPTIONS = ['', 'report', 'move', 'remove', 'nothing', 'restore', 'clear'];
+
+let _bid = 0;
+const nextId = () => `blk_${(_bid += 1)}`;
+const emptyBlock = () => ({
+    _id: nextId(),
+    label: '',
+    enabled: true,
+    schedule: '',
+    mode: '',
+    extra: '',
+});
+
+// Split stored override objects into the mode field + advanced JSON (the rest),
+// for editing. Adds a stable _id so list keys survive add/remove.
+export const blocksFromConfig = (raw = []) =>
+    (raw || []).map(b => {
+        const ov = b.overrides || {};
+        const { mode, ...rest } = ov;
+        return {
+            _id: nextId(),
+            label: b.label || '',
+            enabled: b.enabled !== false,
+            schedule: b.schedule || '',
+            mode: mode || '',
+            extra: Object.keys(rest).length ? JSON.stringify(rest) : '',
+        };
+    });
+
+// Rebuild the API payload. Throws on invalid advanced JSON so the caller can
+// surface a toast and keep the modal open.
+export const blocksToConfig = blocks =>
+    blocks.map((b, i) => {
+        let extra = {};
+        const trimmed = (b.extra || '').trim();
+        if (trimmed) {
+            try {
+                extra = JSON.parse(trimmed);
+            } catch {
+                throw new Error(`Block ${i + 1}: advanced overrides is not valid JSON`);
+            }
+            if (extra === null || typeof extra !== 'object' || Array.isArray(extra)) {
+                throw new Error(`Block ${i + 1}: advanced overrides must be a JSON object`);
+            }
+        }
+        const overrides = { ...extra, ...(b.mode ? { mode: b.mode } : {}) };
+        return {
+            label: b.label || '',
+            enabled: b.enabled !== false,
+            schedule: b.schedule || '',
+            overrides,
+        };
+    });
+
+export const ScheduleBlocksEditor = ({ blocks, onChange, disabled }) => {
+    const update = useCallback(
+        (idx, patch) => {
+            onChange(blocks.map((b, i) => (i === idx ? { ...b, ...patch } : b)));
+        },
+        [blocks, onChange]
+    );
+    const add = useCallback(() => onChange([...blocks, emptyBlock()]), [blocks, onChange]);
+    const remove = useCallback(
+        idx => onChange(blocks.filter((_, i) => i !== idx)),
+        [blocks, onChange]
+    );
+
+    return (
+        <div className="flex flex-col gap-3 mt-4 pt-4 border-t border-border">
+            <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-primary">Schedule blocks</span>
+                <span className="text-xs text-tertiary">
+                    Extra schedules, each with its own overrides — e.g. a daily{' '}
+                    <span className="text-secondary">report</span> plus a weekly{' '}
+                    <span className="text-secondary">remove</span>.
+                </span>
+            </div>
+
+            {blocks.map((b, i) => (
+                <div
+                    key={b._id}
+                    className="rounded-lg border border-border bg-surface-alt p-3 flex flex-col gap-2"
+                >
+                    <div className="flex items-center gap-2">
+                        <input
+                            type="text"
+                            value={b.label}
+                            disabled={disabled}
+                            onChange={e => update(i, { label: e.target.value })}
+                            placeholder={`Block ${i + 1} label`}
+                            className="flex-1 px-2 py-1 rounded bg-surface border border-border text-sm"
+                        />
+                        <label className="flex items-center gap-1 text-xs cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={b.enabled}
+                                disabled={disabled}
+                                onChange={e => update(i, { enabled: e.target.checked })}
+                            />
+                            Enabled
+                        </label>
+                        <Button variant="ghost" onClick={() => remove(i)} disabled={disabled}>
+                            Remove
+                        </Button>
+                    </div>
+
+                    <ScheduleField
+                        field={{ key: `block-${i}-schedule`, label: 'Schedule', required: false }}
+                        value={b.schedule}
+                        onChange={v => update(i, { schedule: v })}
+                        disabled={disabled}
+                    />
+
+                    <label className="flex items-center gap-2 text-sm">
+                        Mode override:
+                        <select
+                            value={b.mode}
+                            disabled={disabled}
+                            onChange={e => update(i, { mode: e.target.value })}
+                            className="bg-surface border border-border rounded px-2 py-1 text-sm"
+                        >
+                            {MODE_OPTIONS.map(m => (
+                                <option key={m} value={m}>
+                                    {m || '— none —'}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+
+                    <label className="flex flex-col gap-1 text-xs text-tertiary">
+                        Advanced overrides (JSON, optional)
+                        <input
+                            type="text"
+                            value={b.extra}
+                            disabled={disabled}
+                            onChange={e => update(i, { extra: e.target.value })}
+                            placeholder='{"stale_duplicates_enabled": true}'
+                            className="px-2 py-1 rounded bg-surface border border-border text-sm font-mono text-secondary"
+                        />
+                    </label>
+                </div>
+            ))}
+
+            <div>
+                <Button variant="secondary" onClick={add} disabled={disabled}>
+                    + Add schedule block
+                </Button>
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/pages/poster/PosterCleanarrPage.jsx
+++ b/frontend/src/pages/poster/PosterCleanarrPage.jsx
@@ -91,6 +91,25 @@ const formatBytes = bytes => {
 // Module-level so reference is stable across renders (fixes exhaustive-deps warning).
 const TERMINAL_STATUSES = ['success', 'error', 'cancelled'];
 
+// ---------------------------------------------------------------------------
+// Stale-duplicate → bundle matching helpers
+// ---------------------------------------------------------------------------
+// A stale asset folder is identified by its {tvdb/tmdb} id; the scan resolves
+// that to a Plex rating_key + title/year via plex_media_cache. The cached
+// rating_key frequently drifts from the live bundle scan (a re-add/re-match
+// mints a new key), so we match by rating_key first, then fall back to the
+// Plex title+year, then the folder's own parsed title+year.
+const normTitle = t => (t || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+const titleYearKey = (title, year) => `${normTitle(title)}|${year ?? ''}`;
+// Parse "Show Name (2019) {tvdb-123}" → { title: 'Show Name', year: 2019 }.
+const parseFolderTitleYear = name => {
+    const noId = (name || '').replace(/\s*\{[^}]*\}\s*$/, '');
+    const ym = noId.match(/\((\d{4})\)\s*$/);
+    const year = ym ? Number(ym[1]) : null;
+    const title = noId.replace(/\s*\(\d{4}\)\s*$/, '').trim();
+    return { title, year };
+};
+
 // Matches Tailwind's `md` breakpoint (already used by the thumbnail grid below).
 // Below this we collapse the master-detail layout into a single column and
 // toggle between list/detail views based on selection.
@@ -413,9 +432,15 @@ const PosterCleanarrPage = () => {
     const [cleanBloat, setCleanBloat] = useState(true);
     const [cleanStale, setCleanStale] = useState(false);
     const [cleanOrphan, setCleanOrphan] = useState(false);
+    // Narrow the bloat pass to Kometa overlay images only (matched by EXIF tag),
+    // sparing user-uploaded customs. Only applies when bloat is running.
+    const [cleanOverlaysOnly, setCleanOverlaysOnly] = useState(false);
 
-    // Stale-duplicate + orphan data from the Kometa assets scan.
-    const [staleByRk, setStaleByRk] = useState(() => new Map());
+    // Stale-duplicate + orphan data from the Kometa assets scan. We keep the
+    // raw stale list (not a pre-built rating_key map) because the cached Plex
+    // rating_key drifts from the live bundle scan — matching is done below
+    // against the actual bundle set by rating_key, then Plex title+year.
+    const [staleItems, setStaleItems] = useState([]);
     const [orphans, setOrphans] = useState([]);
 
     useEffect(() => {
@@ -425,17 +450,12 @@ const PosterCleanarrPage = () => {
             .then(res => {
                 if (cancelled) return;
                 const data = res?.data || {};
-                const map = new Map();
-                for (const s of data.stale || []) {
-                    if (s.rating_key == null) continue;
-                    map.set(s.rating_key, (map.get(s.rating_key) || 0) + 1);
-                }
-                setStaleByRk(map);
+                setStaleItems(data.stale || []);
                 setOrphans(data.orphans || []);
             })
             .catch(() => {
                 if (!cancelled) {
-                    setStaleByRk(new Map());
+                    setStaleItems([]);
                     setOrphans([]);
                 }
             });
@@ -558,6 +578,33 @@ const PosterCleanarrPage = () => {
         for (const b of bundles) m.set(b.rating_key, buildBundleTree(b));
         return m;
     }, [bundles]);
+
+    // Attribute each stale folder to a bundle: rating_key first, then Plex
+    // title+year, then the folder's own parsed title+year. Folders that match
+    // no bundle (no poster row exists, or the title isn't in Plex) are surfaced
+    // separately so they aren't silently dropped.
+    const { staleByRk, unmatchedStale } = useMemo(() => {
+        const counts = new Map();
+        const unmatched = [];
+        if (!staleItems.length) return { staleByRk: counts, unmatchedStale: unmatched };
+        const byRk = new Map();
+        const byTY = new Map();
+        for (const b of bundles) {
+            byRk.set(String(b.rating_key), b);
+            byTY.set(titleYearKey(b.title, b.year), b);
+        }
+        for (const s of staleItems) {
+            let b = s.rating_key != null ? byRk.get(String(s.rating_key)) : null;
+            if (!b && s.plex_title) b = byTY.get(titleYearKey(s.plex_title, s.plex_year));
+            if (!b) {
+                const { title, year } = parseFolderTitleYear(s.canonical || s.name);
+                b = byTY.get(titleYearKey(title, year));
+            }
+            if (b) counts.set(b.rating_key, (counts.get(b.rating_key) || 0) + 1);
+            else unmatched.push(s);
+        }
+        return { staleByRk: counts, unmatchedStale: unmatched };
+    }, [staleItems, bundles]);
 
     // Persist view/tree state (tab, expansion, selection). `hasScanned` is
     // deliberately excluded — scans must be explicit (see state decl).
@@ -689,6 +736,9 @@ const PosterCleanarrPage = () => {
             body.orphan_assets_enabled = cleanOrphan;
             if (cleanStale) body.stale_duplicates_mode = mode;
             if (cleanOrphan) body.orphan_assets_mode = mode;
+            // Overlays-only narrows the bloat pass to Kometa overlay images;
+            // only meaningful when bloat is actually running.
+            body.overlays_only = cleanBloat && cleanOverlaysOnly;
             const res = await postersAPI.runPlexMetadataCleanup(body);
             const jobId = res?.data?.job_id;
             if (!jobId) {
@@ -708,7 +758,7 @@ const PosterCleanarrPage = () => {
         } finally {
             setIsEnqueuing(false);
         }
-    }, [mode, cleanBloat, cleanStale, cleanOrphan, selectedPaths, toast]);
+    }, [mode, cleanBloat, cleanStale, cleanOrphan, cleanOverlaysOnly, selectedPaths, toast]);
 
     const runCleanup = () => {
         // Report mode is the UI scan — populate tiles, don't enqueue a backend
@@ -838,6 +888,9 @@ const PosterCleanarrPage = () => {
         ? detail.variants.filter(v => (v.cls?.source || 'uploads') === 'plex').length
         : 0;
     const activeInDetail = detail ? detail.variants.filter(v => v.active).length : 0;
+    // Stale duplicates are a property of the whole media item, not a single
+    // node — surface the bundle's count on any node within it.
+    const staleInDetail = detail ? staleByRk.get(detail.bundle.rating_key) || 0 : 0;
     const reclaimableBytes = detail
         ? detail.variants
               .filter(v => !v.active && (v.cls?.source || 'uploads') !== 'plex')
@@ -876,6 +929,16 @@ const PosterCleanarrPage = () => {
                         {stats.bundle_count} items · {stats.variant_count} variants ·{' '}
                         <span className="text-error">{stats.bloat_count} bloat</span> ·{' '}
                         {formatBytes(stats.bloat_size)} reclaimable
+                        {staleItems.length > 0 && (
+                            <>
+                                {' '}
+                                ·{' '}
+                                <span style={{ color: '#f59e0b' }}>
+                                    {staleItems.length} stale duplicate
+                                    {staleItems.length === 1 ? '' : 's'}
+                                </span>
+                            </>
+                        )}
                     </div>
                     <div className="flex items-center gap-3 text-xs text-tertiary mt-1">
                         <span className="flex items-center gap-1">
@@ -884,6 +947,11 @@ const PosterCleanarrPage = () => {
                         <span className="flex items-center gap-1">
                             <span style={stalePill}>⧉</span> stale duplicate
                         </span>
+                        {unmatchedStale.length > 0 && (
+                            <span>
+                                {unmatchedStale.length} stale not matched to a Plex item (see below)
+                            </span>
+                        )}
                         {orphans.length > 0 && (
                             <span>orphaned assets: {orphans.length} (see below)</span>
                         )}
@@ -945,6 +1013,20 @@ const PosterCleanarrPage = () => {
                             onChange={e => setCleanOrphan(e.target.checked)}
                         />
                         Orphan
+                    </label>
+                    <label
+                        className={`flex items-center gap-1 ${
+                            cleanBloat ? 'cursor-pointer' : 'opacity-40 cursor-not-allowed'
+                        }`}
+                        title="Limit the bloat pass to Kometa overlay images (EXIF-tagged), sparing user-uploaded customs"
+                    >
+                        <input
+                            type="checkbox"
+                            checked={cleanOverlaysOnly}
+                            disabled={!cleanBloat}
+                            onChange={e => setCleanOverlaysOnly(e.target.checked)}
+                        />
+                        Overlays only
                     </label>
                 </div>
                 <div className="ml-auto flex items-center gap-2">
@@ -1161,6 +1243,16 @@ const PosterCleanarrPage = () => {
                                                     <span className="text-error">
                                                         {bloatInDetail} bloat here
                                                     </span>
+                                                    {staleInDetail > 0 && (
+                                                        <>
+                                                            {' '}
+                                                            ·{' '}
+                                                            <span style={{ color: '#f59e0b' }}>
+                                                                {staleInDetail} stale duplicate
+                                                                {staleInDetail === 1 ? '' : 's'}
+                                                            </span>
+                                                        </>
+                                                    )}
                                                     {selected?.kind === 'show' &&
                                                         subtreeBloat > bloatInDetail && (
                                                             <>
@@ -1263,6 +1355,37 @@ const PosterCleanarrPage = () => {
                             )}
                         </div>
                     </section>
+
+                    {unmatchedStale.length > 0 && (
+                        <section className="rounded-lg border border-border bg-surface mt-4 p-4">
+                            <div className="flex items-center gap-2 mb-3">
+                                <h2 className="text-sm font-semibold text-primary">
+                                    Stale duplicates without a Plex poster row
+                                </h2>
+                                <span style={typeBadge}>{unmatchedStale.length}</span>
+                                <span className="text-tertiary text-xs">
+                                    Renamed asset folders whose title isn&apos;t in the Plex bundle
+                                    scan — still cleaned by the Stale pass
+                                </span>
+                            </div>
+                            <div className="overflow-y-auto" style={{ maxHeight: '320px' }}>
+                                {unmatchedStale.map(s => (
+                                    <div
+                                        key={s.folder || s.name}
+                                        className="flex items-center justify-between gap-2 py-1.5 border-b border-border text-sm"
+                                    >
+                                        <span className="truncate text-secondary">
+                                            <span style={stalePill}>⧉</span> {s.name}
+                                            <span className="text-tertiary"> → {s.canonical}</span>
+                                        </span>
+                                        <span className="text-tertiary text-xs whitespace-nowrap">
+                                            {formatBytes(s.size)}
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        </section>
+                    )}
 
                     {orphans.length > 0 && (
                         <section className="rounded-lg border border-border bg-surface mt-4 p-4">

--- a/frontend/src/pages/poster/PosterCleanarrPage.jsx
+++ b/frontend/src/pages/poster/PosterCleanarrPage.jsx
@@ -121,7 +121,19 @@ const classifyVariant = variant => {
     // strip the source prefix so path-matching below is stable
     const body = rel.replace(/^Uploads\//, '').replace(/^Contents\//, '');
 
-    const se = body.match(/posters\/seasons\/(\d+)\/episodes\/(\d+)/);
+    // Category from the top-level folder. Background art / banners can be set
+    // per-season too, so the season segment isn't unique to posters/.
+    const category =
+        body.startsWith('art/') || body.startsWith('Art/')
+            ? 'Background art'
+            : body.startsWith('banners/') || body.startsWith('Banners/')
+              ? 'Banner'
+              : 'Poster';
+
+    // Match the season/episode segment wherever it sits (posters/seasons/…,
+    // art/seasons/…, banners/seasons/…) so per-season art and banners nest
+    // under their season instead of piling onto the show node.
+    const se = body.match(/seasons\/(\d+)\/episodes\/(\d+)/);
     if (se) {
         return {
             source,
@@ -131,19 +143,20 @@ const classifyVariant = variant => {
             context: `S${String(se[1]).padStart(2, '0')} · E${String(se[2]).padStart(2, '0')}`,
         };
     }
-    const s = body.match(/posters\/seasons\/(\d+)\//);
+    const s = body.match(/seasons\/(\d+)\//);
     if (s) {
+        const n = Number(s[1]);
         return {
             source,
             level: 'season',
-            season: Number(s[1]),
-            context: `Season ${Number(s[1])}`,
+            season: n,
+            context: category === 'Poster' ? `Season ${n}` : `Season ${n} · ${category}`,
         };
     }
-    if (body.startsWith('art/') || body.startsWith('Art/')) {
+    if (category === 'Background art') {
         return { source, level: 'show', context: 'Background art' };
     }
-    if (body.startsWith('banners/') || body.startsWith('Banners/')) {
+    if (category === 'Banner') {
         return { source, level: 'show', context: 'Banner' };
     }
     return { source, level: 'show', context: 'Show poster' };

--- a/frontend/src/pages/settings/SchedulePage.jsx
+++ b/frontend/src/pages/settings/SchedulePage.jsx
@@ -11,6 +11,11 @@ import { StatGrid } from '../../components/statistics';
 import { StatCard, Button, Modal } from '../../components/ui';
 import { ScheduleCard } from '../../components/modules/ScheduleCard';
 import { ScheduleField } from '../../components/fields/custom/ScheduleField';
+import {
+    ScheduleBlocksEditor,
+    blocksFromConfig,
+    blocksToConfig,
+} from '../../components/modules/ScheduleBlocksEditor';
 
 export const SchedulePage = () => {
     // Toast for notifications
@@ -20,6 +25,7 @@ export const SchedulePage = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingModule, setEditingModule] = useState(null);
     const [scheduleValue, setScheduleValue] = useState('');
+    const [blockValue, setBlockValue] = useState([]);
     const [isSaving, setIsSaving] = useState(false);
 
     // API Data - Schedule
@@ -79,6 +85,11 @@ export const SchedulePage = () => {
         }
         return grouped;
     }, [scheduleData?.data?.sub_schedules]);
+    // Editable multi-block schedules keyed by module.
+    const scheduleBlocksByModule = useMemo(
+        () => scheduleData?.data?.schedule_blocks || {},
+        [scheduleData?.data?.schedule_blocks]
+    );
     const availableModules = useMemo(
         () =>
             moduleOrder
@@ -139,9 +150,10 @@ export const SchedulePage = () => {
             // Set modal state and open
             setEditingModule(module);
             setScheduleValue(currentSchedule);
+            setBlockValue(blocksFromConfig(scheduleBlocksByModule[moduleKey] || []));
             setIsModalOpen(true);
         },
-        [availableModules, schedules]
+        [availableModules, schedules, scheduleBlocksByModule]
     );
 
     const handleModalClose = useCallback(() => {
@@ -150,6 +162,7 @@ export const SchedulePage = () => {
         setIsModalOpen(false);
         setEditingModule(null);
         setScheduleValue('');
+        setBlockValue([]);
         setIsSaving(false);
     }, [isSaving]);
 
@@ -160,6 +173,16 @@ export const SchedulePage = () => {
     const handleSave = useCallback(async () => {
         if (!editingModule || isSaving) return;
 
+        // Validate/serialize blocks before any write so an invalid advanced
+        // JSON override aborts cleanly without a partial save.
+        let payloadBlocks;
+        try {
+            payloadBlocks = blocksToConfig(blockValue);
+        } catch (error) {
+            toast.error(error.message || 'Invalid schedule block');
+            return;
+        }
+
         setIsSaving(true);
 
         try {
@@ -167,6 +190,12 @@ export const SchedulePage = () => {
             await scheduleAPI.updateSchedule({
                 module: editingModule.key,
                 schedule: scheduleValue,
+            });
+
+            // Persist the module's multi-block schedules.
+            await scheduleAPI.updateScheduleBlocks({
+                module: editingModule.key,
+                blocks: payloadBlocks,
             });
 
             // Refresh schedule data (bypass cache to show updated data)
@@ -184,7 +213,15 @@ export const SchedulePage = () => {
             toast.error(`Failed to save schedule: ${error.message || 'Unknown error'}`);
             setIsSaving(false);
         }
-    }, [editingModule, scheduleValue, toast, refetchSchedules, handleModalClose, isSaving]);
+    }, [
+        editingModule,
+        scheduleValue,
+        blockValue,
+        toast,
+        refetchSchedules,
+        handleModalClose,
+        isSaving,
+    ]);
 
     const handleRemove = useCallback(async () => {
         if (!editingModule || isSaving) return;
@@ -290,17 +327,25 @@ export const SchedulePage = () => {
                 <Modal.Header>Configure Schedule - {editingModule?.label || 'Module'}</Modal.Header>
                 <Modal.Body>
                     {editingModule && (
-                        <ScheduleField
-                            field={{
-                                key: 'schedule',
-                                label: 'Schedule Configuration',
-                                description: 'Configure when this module should run automatically',
-                                required: false,
-                            }}
-                            value={scheduleValue}
-                            onChange={handleScheduleChange}
-                            disabled={isSaving}
-                        />
+                        <>
+                            <ScheduleField
+                                field={{
+                                    key: 'schedule',
+                                    label: 'Schedule Configuration',
+                                    description:
+                                        'Configure when this module should run automatically',
+                                    required: false,
+                                }}
+                                value={scheduleValue}
+                                onChange={handleScheduleChange}
+                                disabled={isSaving}
+                            />
+                            <ScheduleBlocksEditor
+                                blocks={blockValue}
+                                onChange={setBlockValue}
+                                disabled={isSaving}
+                            />
+                        </>
                     )}
                 </Modal.Body>
                 <Modal.Footer>

--- a/frontend/src/utils/api/schedule.js
+++ b/frontend/src/utils/api/schedule.js
@@ -40,6 +40,16 @@ export const scheduleAPI = {
     },
 
     /**
+     * Replace a module's multi-block schedules (each block has its own
+     * schedule string + overrides applied to that run only).
+     * @param {Object} data - { module, blocks: Array<{label,enabled,schedule,overrides}> }
+     * @returns {Promise<Object>} Update response
+     */
+    updateScheduleBlocks: data => {
+        return apiCore.post('/schedule/blocks', data);
+    },
+
+    /**
      * Delete module schedule
      * @param {string} moduleId - Module identifier
      * @returns {Promise<Object>} Deletion response

--- a/tests/test_posters_api_kometa_scan.py
+++ b/tests/test_posters_api_kometa_scan.py
@@ -13,21 +13,28 @@ def _logger():
     )
 
 
-def test_resolve_rating_keys_via_plex_mapping(tmp_path):
-    from backend.api.posters import _stale_rating_key_map
+def test_resolve_plex_match_via_plex_mapping(tmp_path):
+    from backend.api.posters import _stale_plex_match_map
 
     with ChubDB(_logger(), db_path=str(tmp_path / "chub.db")) as db:
         db.media.execute_query(
-            "INSERT INTO plex_media_cache (id, plex_id, instance_name) VALUES (?,?,?)",
-            (5, "12345", "Chodeus"),
+            "INSERT INTO plex_media_cache (id, plex_id, instance_name, title, year) "
+            "VALUES (?,?,?,?,?)",
+            (5, "12345", "Chodeus", "Euphoria", 2019),
         )
         db.media.execute_query(
             "INSERT INTO media_cache (identity_key, instance_name, tvdb_id, "
             "plex_mapping_id, asset_type, matched) VALUES (?,?,?,?,?,1)",
             ("k", "sonarr", 367118, 5, "show"),
         )
-        m = _stale_rating_key_map(db, [("tvdb", 367118)])
-        assert m[("tvdb", 367118)] == 12345
+        m = _stale_plex_match_map(db, [("tvdb", 367118)])
+        # rating_key for the drifted-cache fallback, plus the Plex title+year
+        # the UI matches on when the rating_key no longer lines up with a bundle.
+        assert m[("tvdb", 367118)] == {
+            "rating_key": 12345,
+            "title": "Euphoria",
+            "year": 2019,
+        }
 
 
 def test_cleanup_overrides_parse_stale():
@@ -43,6 +50,15 @@ def test_cleanup_overrides_parse_stale():
     assert ov["mode"] == "remove"
     assert ov["stale_duplicates_enabled"] is True
     assert ov["stale_duplicates_mode"] == "move"
+
+
+def test_cleanup_overrides_parse_overlays_only():
+    from backend.api.posters import _build_cleanup_overrides
+
+    assert _build_cleanup_overrides({"overlays_only": True})["overlays_only"] is True
+    assert _build_cleanup_overrides({"overlays_only": False})["overlays_only"] is False
+    # absent -> not in overrides (module keeps its saved overlays_only)
+    assert "overlays_only" not in _build_cleanup_overrides({"mode": "report"})
 
 
 def test_cleanup_overrides_allows_nothing_and_rejects_bad_stale_mode():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -288,3 +288,111 @@ def test_scheduler_does_not_double_run_upgradinatorr(monkeypatch):
     assert orch.calls[0][0][0] == "upgradinatorr"
     # Args/kwargs should be plain "scheduled" origin, not profile overrides
     assert orch.calls[0][0][1] == "scheduled"
+
+
+# --- ChubScheduler multi-block schedules (schedule_blocks) ---
+
+
+def test_scheduler_schedule_block_fires_with_overrides(monkeypatch):
+    monkeypatch.setattr(scheduler, "datetime", FixedNow)
+    cfg = SimpleNamespace(
+        schedule={},
+        upgradinatorr=SimpleNamespace(instances_list=[]),
+        schedule_blocks={
+            "poster_cleanarr": [
+                SimpleNamespace(
+                    label="daily report",
+                    enabled=True,
+                    schedule="daily(09:00)",
+                    overrides={"mode": "report"},
+                ),
+            ]
+        },
+    )
+    orch = FakeOrchOK()
+    s = ChubScheduler(cfg, logger=None, module_orchestrator=orch)
+    s._tick(cfg.schedule)
+    assert len(orch.calls) == 1
+    args, kwargs = orch.calls[0]
+    assert args[0] == "poster_cleanarr"
+    assert kwargs["overrides"] == {"mode": "report"}
+
+
+def test_scheduler_schedule_block_disabled_and_empty_skipped(monkeypatch):
+    monkeypatch.setattr(scheduler, "datetime", FixedNow)
+    cfg = SimpleNamespace(
+        schedule={},
+        upgradinatorr=SimpleNamespace(instances_list=[]),
+        schedule_blocks={
+            "poster_cleanarr": [
+                SimpleNamespace(
+                    label="off",
+                    enabled=False,
+                    schedule="daily(09:00)",
+                    overrides={"mode": "remove"},
+                ),
+                SimpleNamespace(
+                    label="no-sched", enabled=True, schedule="", overrides={}
+                ),
+            ]
+        },
+    )
+    orch = FakeOrchOK()
+    s = ChubScheduler(cfg, logger=None, module_orchestrator=orch)
+    s._tick(cfg.schedule)
+    assert orch.calls == []
+
+
+def test_scheduler_schedule_block_skips_already_queued(monkeypatch):
+    """A top-level schedule already queued the module — blocks must not re-fire."""
+    monkeypatch.setattr(scheduler, "datetime", FixedNow)
+    cfg = SimpleNamespace(
+        schedule={"poster_cleanarr": "daily(09:00)"},
+        upgradinatorr=SimpleNamespace(instances_list=[]),
+        schedule_blocks={
+            "poster_cleanarr": [
+                SimpleNamespace(
+                    label="b",
+                    enabled=True,
+                    schedule="daily(09:00)",
+                    overrides={"mode": "remove"},
+                ),
+            ]
+        },
+    )
+    orch = FakeOrchOK()
+    s = ChubScheduler(cfg, logger=None, module_orchestrator=orch)
+    s._tick(cfg.schedule)
+    assert len(orch.calls) == 1
+    args, _ = orch.calls[0]
+    assert args[1] == "scheduled"  # top-level origin, not a block dispatch
+
+
+def test_scheduler_schedule_blocks_merge_overrides_last_wins(monkeypatch):
+    monkeypatch.setattr(scheduler, "datetime", FixedNow)
+    cfg = SimpleNamespace(
+        schedule={},
+        upgradinatorr=SimpleNamespace(instances_list=[]),
+        schedule_blocks={
+            "poster_cleanarr": [
+                SimpleNamespace(
+                    label="a",
+                    enabled=True,
+                    schedule="daily(09:00)",
+                    overrides={"mode": "report", "orphan_assets_enabled": True},
+                ),
+                SimpleNamespace(
+                    label="b",
+                    enabled=True,
+                    schedule="weekly(monday@09:00)",
+                    overrides={"mode": "remove"},
+                ),
+            ]
+        },
+    )
+    orch = FakeOrchOK()
+    s = ChubScheduler(cfg, logger=None, module_orchestrator=orch)
+    s._tick(cfg.schedule)
+    assert len(orch.calls) == 1
+    _, kwargs = orch.calls[0]
+    assert kwargs["overrides"] == {"mode": "remove", "orphan_assets_enabled": True}


### PR DESCRIPTION
Three changes, one per commit.

## fix(poster-cleanarr): match stale duplicates by Plex title+year; add overlays-only toggle
Stale folders were joined to poster rows only by the cached Plex `rating_key`, which drifts from the live bundle scan (a re-add/re-match mints a new key) — so most stale duplicates never surfaced (live: 7/31). Now resolves each stale folder's Plex title+year from `plex_media_cache` and matches `rating_key → Plex title+year → folder title+year` (~28/31), listing any that match no row in a dedicated note instead of silently dropping them. Surfaces a stale total + a detail-pane count. Also exposes the existing `overlays_only` cleanup option as a toggle on the action bar.

Note: cleanup ≠ visibility — the Stale pass cleans all stale folders on disk regardless of whether they show a UI row.

## fix(poster-cleanarr): nest per-season art and banners under their season
`classifyVariant` only bucketed `posters/seasons/<n>/`; `art/seasons/<n>/` and `banners/seasons/<n>/` fell through to show level, piling every season's background art onto the show node as identical repeats. Now matches the season segment under any category.

## feat(scheduler): add per-schedule-block overrides
Modules can define multiple schedule blocks, each firing on its own schedule with its own config overrides (e.g. report daily, remove weekly). Additive `schedule_blocks` config + a generic scheduler tick mirroring the Upgradinatorr per-instance precedent, a new `POST /schedule/blocks`, and a block editor in the schedule modal.

## Verification
`ruff check .` ✅ · `pytest` 983 passed (5 new) ✅ · `npm run lint` ✅ · `prettier --check src` ✅

All shared code on a `main`-based branch (no extension files), ready to merge into `develop` after landing.