### PR TITLE
fix(poster_renamerr): report only genuine Plex uploads and stop steady-state border churn

### DIFF
--- a/backend/modules/border_replacerr.py
+++ b/backend/modules/border_replacerr.py
@@ -1,10 +1,12 @@
 # modules/border_replacerr.py
 
+import contextlib
 import filecmp
 import hashlib
 import logging
 import os
 import re
+import shutil
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -380,6 +382,40 @@ class BorderReplacerr(ChubModule):
             return True
         return False
 
+    def _stage_unbordered(self, asset: dict) -> None:
+        """A border-excluded asset still needs its poster staged: with borders
+        enabled poster_renamerr skips the copy (the border op is the sole file
+        writer), so an excluded title would otherwise never get a file at
+        renamed_file — on the plex path the uploader then fails to read it on
+        every run, and on the kometa path the destination stays empty. Copy
+        the raw source to renamed_file (temp-name + os.replace, crash-safe)
+        when it is missing or differs; never in dry-run. Best-effort — a
+        failure only warns.
+        """
+        src = asset.get("original_file")
+        dest = asset.get("renamed_file")
+        if not src or not dest or self.config.dry_run:
+            return
+        try:
+            if not os.path.exists(src):
+                return
+            if os.path.exists(dest) and filecmp.cmp(src, dest, shallow=False):
+                return
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            tmp = f"{dest}.chub-tmp-{os.getpid()}"
+            try:
+                shutil.copyfile(src, tmp)
+                os.replace(tmp, dest)
+            except OSError:
+                with contextlib.suppress(OSError):
+                    os.remove(tmp)
+                raise
+            self.logger.debug(f"[EXCLUDED_COPY] {dest} ← {src} (unbordered)")
+        except OSError as e:
+            self.logger.warning(
+                f"Could not stage excluded asset '{asset.get('title')}': {e}"
+            )
+
     def _collect_matched_assets(self, db) -> list:
         """Return every matched media row + matched collection row, with
         exclusion_list / ignore_folders applied.
@@ -397,12 +433,14 @@ class BorderReplacerr(ChubModule):
             if row.get("matched") != 1:
                 continue
             if self._asset_excluded(row):
+                self._stage_unbordered(row)
                 continue
             assets.append(row)
         for row in db.collection.get_all():
             if row.get("matched") != 1:
                 continue
             if self._asset_excluded(row):
+                self._stage_unbordered(row)
                 continue
             assets.append(row)
         return assets
@@ -418,7 +456,20 @@ class BorderReplacerr(ChubModule):
         manifest subset (webhook/adhoc imports)."""
         return bool(process_all or reset_all or manifest is None)
 
-    def run(self, manifest: Optional[dict] = None, process_all: bool = False):
+    def run(
+        self,
+        manifest: Optional[dict] = None,
+        process_all: bool = False,
+        manifest_only: bool = False,
+    ):
+        # manifest_only is a HARD restriction for the plex apply path: staged
+        # files live in a per-run temp dir and only manifest assets upload, so
+        # a full-library sweep (process_all, a holiday reset_all edge, or a
+        # missing manifest) would re-encode skipped posters into dead temp
+        # paths from prior runs — recreating and leaking those dirs for
+        # nothing. It overrides every full-library trigger.
+        if manifest_only:
+            manifest = manifest or {"media_cache": [], "collections_cache": []}
         with ChubDB(logger=self.logger) as db:
             if self.config.log_level.lower() == "debug":
                 print_settings(self.logger, self.config)
@@ -434,7 +485,9 @@ class BorderReplacerr(ChubModule):
             skipped = 0
             failed = 0
             gate_skipped = 0
-            if self._should_process_all(manifest, process_all, reset_all):
+            if not manifest_only and self._should_process_all(
+                manifest, process_all, reset_all
+            ):
                 self.logger.debug(
                     "Full-library border pass: reprocessing all matched media "
                     "and collections (includes already-moved posters)."
@@ -454,21 +507,11 @@ class BorderReplacerr(ChubModule):
                             f"Asset ID {asset_id} not found in {source}. Skipping."
                         )
                         continue
-                    if (
-                        self.config.exclusion_list
-                        and asset["title"] in self.config.exclusion_list
-                    ):
-                        self.logger.debug(
-                            f"Skipping '{asset['title']}' (in exclusion_list)."
-                        )
-                        continue
-                    if (
-                        self.config.ignore_folders
-                        and asset.get("folder") in self.config.ignore_folders
-                    ):
-                        self.logger.debug(
-                            f"Skipping '{asset['title']}' (folder in ignore_folders)."
-                        )
+                    if self._asset_excluded(asset):
+                        # Excluded from borders, not from posters: stage the
+                        # raw source so the asset still reaches its
+                        # destination / the Plex uploader without a border.
+                        self._stage_unbordered(asset)
                         continue
                     assets.append(asset)
 

--- a/backend/modules/poster_renamerr.py
+++ b/backend/modules/poster_renamerr.py
@@ -1244,6 +1244,45 @@ class PosterRenamerr(ChubModule):
         self._report_progress(progress_ceiling)
         return output, manifest
 
+    @staticmethod
+    def _build_plex_notify_output(upload_result: Optional[dict]) -> dict:
+        """Notification payload for the plex apply path: ONLY the posters the
+        uploader genuinely pushed this run (action == "updated"), in the same
+        {asset_type: [{title, year, messages}]} shape the formatter consumes.
+
+        The staged/rename output must NOT feed the notification here — it
+        lists what was staged, so a poster whose upload failed or was skipped
+        (unchanged bytes, re-flow retries) would spam every scheduled run as
+        if it had been uploaded. Failures and skips stay in the log summary.
+        Returns an all-empty shape when nothing genuinely uploaded; the caller
+        then attaches a one-line heartbeat instead of a poster list.
+        """
+        out: Dict[str, List[Dict[str, Any]]] = {
+            "collection": [],
+            "movie": [],
+            "show": [],
+            "artist": [],
+            "album": [],
+        }
+        payload = (upload_result or {}).get("payload") or {}
+        for up in payload.get("uploaded") or []:
+            asset_type = up.get("asset_type") or "movie"
+            season = up.get("season_number")
+            libs = up.get("library_name") or "Plex"
+            msg = (
+                f"Season {str(season).zfill(2)} uploaded to {libs}"
+                if asset_type == "show" and season is not None
+                else f"Uploaded to {libs}"
+            )
+            out.setdefault(asset_type, []).append(
+                {
+                    "title": up.get("title"),
+                    "year": up.get("year"),
+                    "messages": [msg],
+                }
+            )
+        return out
+
     def handle_output(self, output: Dict[str, List[Dict[str, Any]]]):
         headers = {
             "collection": "Collection",
@@ -1630,7 +1669,11 @@ class PosterRenamerr(ChubModule):
         return [self.config.destination_dir] if self.config.destination_dir else []
 
     def run_border_replacerr(
-        self, manifest: Optional[dict], progress_window=None, process_all=False
+        self,
+        manifest: Optional[dict],
+        progress_window=None,
+        process_all=False,
+        manifest_only=False,
     ):
         from backend.modules.border_replacerr import BorderReplacerr
 
@@ -1655,7 +1698,7 @@ class PosterRenamerr(ChubModule):
                 getattr(self, "_job_id", None), getattr(self, "_job_db", None)
             )
             border.set_progress_window(*progress_window)
-        border.run(manifest, process_all=process_all)
+        border.run(manifest, process_all=process_all, manifest_only=manifest_only)
 
         self.logger.info("Finished running border_replacerr.")
 
@@ -1930,18 +1973,28 @@ class PosterRenamerr(ChubModule):
 
                 if self.config.run_border_replacerr:
                     with self._phase("border_replacerr"):
+                        # kometa: full-library pass so a border-settings change
+                        # re-borders the on-disk destination. plex: manifest
+                        # subset ONLY — staged files are transient and only
+                        # manifest assets upload; a full pass would re-encode
+                        # Layer-A-skipped posters into dead temp paths from
+                        # prior runs (leaking recreated dirs) for nothing.
                         self.run_border_replacerr(
                             manifest,
                             progress_window=tail_windows.get("border"),
-                            process_all=True,
+                            process_all=(apply_method != "plex"),
+                            manifest_only=(apply_method == "plex"),
                         )
 
                 # Strict either/or: upload to Plex only on the "plex" path. The
                 # uploader still gates per-instance on add_posters, so only
-                # opted-in Plex servers receive the staged posters.
+                # opted-in Plex servers receive the staged posters. The result
+                # is kept: the notification below reports genuine uploads, not
+                # the staged set.
+                upload_result: Optional[Dict[str, Any]] = None
                 if apply_method == "plex":
                     with self._phase("plex upload"):
-                        PosterUploader(
+                        upload_result = PosterUploader(
                             db=db, logger=self.logger, manifest=manifest
                         ).run()
 
@@ -1972,15 +2025,38 @@ class PosterRenamerr(ChubModule):
                         self.full_config, self.logger, module_name="asset_renamerr"
                     ).send_notification(asset_output)
                 # Always notify on a successful run, even when nothing
-                # was renamed — gives the user a heartbeat that the
-                # module fired. The formatter handles the empty-output
-                # case with a clean "No files were renamed." field.
+                # happened — gives the user a heartbeat that the module fired.
+                # kometa: the rename output IS the outcome (files written for
+                # Kometa), notify from it as before. plex: notify ONLY the
+                # posters the uploader genuinely pushed — staged-but-skipped
+                # and failed posters stay in the logs, so re-flow retries
+                # can't spam the notification every schedule. When nothing
+                # uploaded, a one-line heartbeat replaces the poster list.
                 if any(output.values()):
                     self.handle_output(output)
+                notify_output: Dict[str, Any] = output
+                if apply_method == "plex":
+                    notify_output = self._build_plex_notify_output(upload_result)
+                    if not any(notify_output.values()):
+                        payload = (upload_result or {}).get("payload") or {}
+                        failed = payload.get("failed", 0)
+                        if (upload_result or {}).get("success"):
+                            empty_text = "No posters were uploaded (nothing changed)."
+                        elif failed:
+                            empty_text = (
+                                f"No posters were uploaded "
+                                f"({failed} failed — check the logs)."
+                            )
+                        else:
+                            reason = (upload_result or {}).get(
+                                "message"
+                            ) or "upload did not run"
+                            empty_text = f"No posters were uploaded — {reason}"
+                        notify_output["empty_text"] = empty_text
                 manager = NotificationManager(
                     self.full_config, self.logger, module_name="poster_renamerr"
                 )
-                manager.send_notification(output)
+                manager.send_notification(notify_output)
 
         except KeyboardInterrupt:
             self.logger.info("Keyboard Interrupt detected. Exiting...")

--- a/backend/util/notification_formatting.py
+++ b/backend/util/notification_formatting.py
@@ -249,10 +249,17 @@ def format_for_discord(
             text = "\n".join([section_title] + [f"    {m}" for m in msgs])
             fields.append({"name": section_title, "value": f"```{text}```"})
 
+        add_asset_fields(o.get("artist", []), "Artist")
+
+        add_asset_fields(o.get("album", []), "Album")
+
         if not had_any:
+            # empty_text lets the caller override the heartbeat line (the plex
+            # upload path sends "No posters were uploaded..." instead of the
+            # rename wording).
             fields = [
                 {
-                    "name": "No files were renamed.",
+                    "name": o.get("empty_text") or "No files were renamed.",
                     "value": "",
                 }
             ]

--- a/backend/util/plex.py
+++ b/backend/util/plex.py
@@ -564,7 +564,26 @@ class PlexClient:
             # won't pull a same-named item of the wrong kind.
             candidates = section.search(title=item_title)
             if len(candidates) == 1:
-                items = candidates
+                # Year-guard the lone hit too: a single same-title sibling of a
+                # clearly different year (e.g. a remake) is a different release
+                # and must not receive this poster. A candidate with NO year is
+                # kept — a metadata gap must not reject the only candidate
+                # (mirrors PlexMediaIndex._disambiguate_by_year).
+                lone_year = getattr(candidates[0], "year", None)
+                try:
+                    year_compatible = (
+                        lone_year is None
+                        or abs(int(lone_year) - int(year)) <= YEAR_MATCH_TOLERANCE
+                    )
+                except (TypeError, ValueError):
+                    year_compatible = True
+                if year_compatible:
+                    items = candidates
+                else:
+                    self.logger.debug(
+                        f"'{item_title}' lone title match in '{library_name}' "
+                        f"rejected: year {lone_year} vs requested {year}"
+                    )
             elif candidates:
                 try:
                     target_year = int(year)

--- a/backend/util/plex.py
+++ b/backend/util/plex.py
@@ -564,11 +564,8 @@ class PlexClient:
             # won't pull a same-named item of the wrong kind.
             candidates = section.search(title=item_title)
             if len(candidates) == 1:
-                # Year-guard the lone hit too: a single same-title sibling of a
-                # clearly different year (e.g. a remake) is a different release
-                # and must not receive this poster. A candidate with NO year is
-                # kept — a metadata gap must not reject the only candidate
-                # (mirrors PlexMediaIndex._disambiguate_by_year).
+                # Reject a clear year mismatch; keep yearless candidates
+                # (metadata gap). Malformed non-empty years fail closed.
                 lone_year = getattr(candidates[0], "year", None)
                 try:
                     year_compatible = (
@@ -576,7 +573,7 @@ class PlexClient:
                         or abs(int(lone_year) - int(year)) <= YEAR_MATCH_TOLERANCE
                     )
                 except (TypeError, ValueError):
-                    year_compatible = True
+                    year_compatible = lone_year in (None, "")
                 if year_compatible:
                     items = candidates
                 else:

--- a/backend/util/upload_posters.py
+++ b/backend/util/upload_posters.py
@@ -39,6 +39,10 @@ class UploadResult:
     reason: str
     library_name: Optional[str] = None
     match_type: Optional[str] = None
+    # Carried so the caller's notification can render "Title (Year)" /
+    # "Season NN" for genuinely uploaded posters without re-querying the DB.
+    year: Optional[Any] = None
+    season_number: Optional[Any] = None
 
 
 @dataclass
@@ -833,17 +837,18 @@ class PosterUploader:
                     if not missing_libs:
                         # Same bytes, every library covered: refresh the mtime
                         # fast-path key (preserving the record) and skip.
-                        self._update_asset_database(
-                            asset,
-                            current_file_hash,
-                            current_mtime,
-                            uploaded_libraries=(
-                                json.dumps(sorted(recorded_libs))
-                                if not dry_run
-                                else None
-                            ),
-                            source_file_hash=source_file_hash,
-                        )
+                        # Never persist in dry-run — a pretend run must not
+                        # touch the hash/mtime record (unreachable today since
+                        # the dry-run hash can't equal a real record hash, but
+                        # keep the guard structural).
+                        if not dry_run:
+                            self._update_asset_database(
+                                asset,
+                                current_file_hash,
+                                current_mtime,
+                                uploaded_libraries=json.dumps(sorted(recorded_libs)),
+                                source_file_hash=source_file_hash,
+                            )
                         return UploadResult(
                             asset_title=asset_title,
                             asset_type=asset_type,
@@ -933,6 +938,8 @@ class PosterUploader:
                     reason="Successfully uploaded",
                     library_name=", ".join(dict.fromkeys(uploaded_libs)),
                     match_type=match_type,
+                    year=asset.get("year"),
+                    season_number=asset.get("season_number"),
                 )
             else:
                 return UploadResult(
@@ -1118,19 +1125,36 @@ class PosterUploader:
         total_skipped = 0
         total_failed = 0
         successful_instances = 0
+        # Per-poster record of every GENUINE upload this run (action ==
+        # 'updated'), across instances. The scheduled plex path notifies from
+        # this — never from the staged/rename output — so a skipped or failed
+        # poster can't masquerade as an upload in Discord/Notifiarr.
+        uploaded_records: List[Dict[str, Any]] = []
 
         for instance_result in instance_results:
             if instance_result.connected and not instance_result.error_message:
                 successful_instances += 1
 
-                updated = len(
-                    [r for r in instance_result.uploads if r.action == "updated"]
-                )
+                updated_results = [
+                    r for r in instance_result.uploads if r.action == "updated"
+                ]
+                updated = len(updated_results)
                 skipped = len(
                     [r for r in instance_result.uploads if r.action == "skipped"]
                 )
                 failed = len(
                     [r for r in instance_result.uploads if r.action == "failed"]
+                )
+                uploaded_records.extend(
+                    {
+                        "title": r.asset_title,
+                        "year": r.year,
+                        "asset_type": r.asset_type,
+                        "season_number": r.season_number,
+                        "library_name": r.library_name,
+                        "instance": instance_result.instance_name,
+                    }
+                    for r in updated_results
                 )
 
                 total_updated += updated
@@ -1186,6 +1210,7 @@ class PosterUploader:
                 "updated": total_updated,
                 "skipped": total_skipped,
                 "failed": total_failed,
+                "uploaded": uploaded_records,
                 "year_discrepancies": list(self._year_discrepancies),
                 "instances_processed": successful_instances,
                 "instance_results": [

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -348,9 +348,10 @@ def test_renamerr_run_border_replacerr_forwards_process_all(monkeypatch):
         def set_progress_window(self, *a, **k):
             pass
 
-        def run(self, manifest=None, process_all=False):
+        def run(self, manifest=None, process_all=False, manifest_only=False):
             captured["manifest"] = manifest
             captured["process_all"] = process_all
+            captured["manifest_only"] = manifest_only
 
     monkeypatch.setattr(border_mod, "BorderReplacerr", _FakeBorder)
 
@@ -362,6 +363,12 @@ def test_renamerr_run_border_replacerr_forwards_process_all(monkeypatch):
 
     assert captured["process_all"] is True
     assert captured["manifest"] == manifest
+    assert captured["manifest_only"] is False
+
+    # plex apply path: manifest_only forwards too (hard-restricts the sweep).
+    renamer.run_border_replacerr(manifest, process_all=False, manifest_only=True)
+    assert captured["process_all"] is False
+    assert captured["manifest_only"] is True
 
 
 # ---- end-to-end: full pass borders all, second pass re-encodes nothing -----
@@ -607,3 +614,113 @@ def test_subset_pass_only_borders_manifest_items(tmp_path, monkeypatch):
 
     assert (dest_dir / "inman.jpg").exists()        # manifest item bordered
     assert not (dest_dir / "outman.jpg").exists()   # non-manifest item untouched
+
+
+def _subset_harness(tmp_path, monkeypatch, exclusion_list=None):
+    """Shared setup for manifest-mode runs: two real source posters (ids 1/2),
+    a fake DB, notifications stubbed. Returns (br, dest_dir, rows_by_id)."""
+    import backend.modules.border_replacerr as border_mod
+    from backend.util.database.border_state import BorderState
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+
+    def _mkrow(id_, name):
+        src = src_dir / f"{name}.jpg"
+        Image.new("RGB", (1000, 1500), (10, 20, 30)).save(src, "JPEG")
+        return {
+            "id": id_,
+            "title": name,
+            "folder": name,
+            "matched": 1,
+            "original_file": str(src),
+            "renamed_file": str(dest_dir / f"{name}.jpg"),
+        }
+
+    by_id = {1: _mkrow(1, "inman"), 2: _mkrow(2, "outman")}
+    border_state = BorderState(logger=StubLogger(), db_path=str(tmp_path / "b.db"))
+
+    class _MediaTable:
+        def get_by_id(self, i):
+            return by_id.get(i)
+
+        def get_all(self):
+            return list(by_id.values())
+
+    class _CollTable:
+        def get_by_id(self, i):
+            return None
+
+        def get_all(self):
+            return []
+
+    class _FakeDB:
+        def __init__(self):
+            self.media = _MediaTable()
+            self.collection = _CollTable()
+            self.holiday = SimpleNamespace(
+                get_status=lambda: {"last_active_holiday": None},
+                set_status=lambda *a, **k: None,
+            )
+            self.border = border_state
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(border_mod, "ChubDB", lambda *a, **k: _FakeDB())
+    monkeypatch.setattr(
+        border_mod,
+        "NotificationManager",
+        lambda *a, **k: SimpleNamespace(send_notification=lambda *a, **k: None),
+    )
+
+    br = _make_br()
+    br.full_config = SimpleNamespace()
+    br.config = SimpleNamespace(
+        log_level="info",
+        holidays=[],
+        border_colors=["#FF0000"],
+        exclusion_list=exclusion_list or [],
+        ignore_folders=[],
+        dry_run=False,
+        border_width=26,
+        border_workers=1,
+    )
+    return br, dest_dir, by_id
+
+
+def test_manifest_only_overrides_full_library_triggers(tmp_path, monkeypatch):
+    """manifest_only must beat process_all (and any full-library trigger): on
+    the plex apply path staged files are transient, so a full sweep would
+    re-encode skipped posters into dead temp paths from prior runs. Only the
+    manifest item may be written."""
+    br, dest_dir, _ = _subset_harness(tmp_path, monkeypatch)
+
+    manifest = {"media_cache": [1], "collections_cache": []}
+    br.run(manifest, process_all=True, manifest_only=True)
+
+    assert (dest_dir / "inman.jpg").exists()        # manifest item bordered
+    assert not (dest_dir / "outman.jpg").exists()   # full sweep suppressed
+
+
+def test_excluded_manifest_asset_staged_unbordered(tmp_path, monkeypatch):
+    """A border-EXCLUDED manifest asset must still get its raw source staged
+    at renamed_file (exclusion means no border, not no poster) — otherwise the
+    plex uploader finds nothing to read and fails it on every run."""
+    br, dest_dir, by_id = _subset_harness(
+        tmp_path, monkeypatch, exclusion_list=["inman"]
+    )
+
+    manifest = {"media_cache": [1], "collections_cache": []}
+    br.run(manifest, process_all=False)
+
+    dest = dest_dir / "inman.jpg"
+    assert dest.exists()
+    # Exact source bytes — copied, not bordered.
+    src_bytes = open(by_id[1]["original_file"], "rb").read()
+    assert dest.read_bytes() == src_bytes

--- a/tests/test_border_replacerr.py
+++ b/tests/test_border_replacerr.py
@@ -722,5 +722,6 @@ def test_excluded_manifest_asset_staged_unbordered(tmp_path, monkeypatch):
     dest = dest_dir / "inman.jpg"
     assert dest.exists()
     # Exact source bytes — copied, not bordered.
-    src_bytes = open(by_id[1]["original_file"], "rb").read()
+    with open(by_id[1]["original_file"], "rb") as f:
+        src_bytes = f.read()
     assert dest.read_bytes() == src_bytes

--- a/tests/test_media_cache_upsert.py
+++ b/tests/test_media_cache_upsert.py
@@ -230,3 +230,53 @@ def test_source_file_hash_persists_and_survives_resync(db):
     got2 = db.media.get_by_id(row["id"])
     assert got2["source_file_hash"] == "deadbeef"  # preserved
     assert got2["title"] == "Film Renamed"  # arr fields still refresh
+
+
+def test_collection_skip_columns_survive_resync(db):
+    """Collection analogue of the media test above: the plex upload dedup
+    record (source_file_hash / uploaded_libraries / file_hash / file_mtime /
+    original_file) must be PRESERVED across a collections re-sync upsert, or
+    every collection would re-upload each scheduled run. Guards the
+    ON CONFLICT DO UPDATE SET column list in collection_cache.upsert."""
+    rec = {
+        "title": "Marvel Collection",
+        "normalized_title": normalize_titles("Marvel Collection"),
+        "year": None,
+        "tmdb_id": 100,
+        "tvdb_id": None,
+        "imdb_id": None,
+        "folder": "/c",
+        "library_name": "Movies",
+    }
+    db.collection.upsert(dict(rec), "plex_main")
+    row = db.collection.execute_query(
+        "SELECT id FROM collections_cache WHERE title='Marvel Collection'",
+        fetch_one=True,
+    )
+    db.collection.update(
+        title="Marvel Collection",
+        year=None,
+        library_name="Movies",
+        instance_name="plex_main",
+        id=row["id"],
+        original_file="/posters/Marvel Collection.jpg",
+        file_hash="feedface",
+        file_mtime=123.0,
+        uploaded_libraries='["Movies"]',
+        source_file_hash="deadbeef",
+    )
+    got = db.collection.get_by_id(row["id"])
+    assert got["source_file_hash"] == "deadbeef"
+    assert got["uploaded_libraries"] == '["Movies"]'
+
+    # Re-sync (same title/library/instance, refreshed id) must refresh arr/plex
+    # fields WITHOUT wiping the upload dedup record.
+    db.collection.upsert({**rec, "tmdb_id": 200, "folder": "/c2"}, "plex_main")
+    got2 = db.collection.get_by_id(row["id"])
+    assert got2["tmdb_id"] == 200  # sync fields still refresh
+    assert got2["folder"] == "/c2"
+    assert got2["source_file_hash"] == "deadbeef"  # preserved
+    assert got2["uploaded_libraries"] == '["Movies"]'  # preserved
+    assert got2["file_hash"] == "feedface"  # preserved
+    assert float(got2["file_mtime"]) == 123.0  # preserved
+    assert got2["original_file"] == "/posters/Marvel Collection.jpg"  # preserved

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -603,3 +603,56 @@ def test_format_for_discord_keeps_small_run_detailed():
     names = [f.get("name", "") for fields in data.values() for f in fields]
     assert any("Movie 0" in n for n in names)  # per-item detail preserved
     assert not any("items processed" in n for n in names)  # not summarised
+
+
+def test_format_for_discord_empty_text_override():
+    """The plex upload path replaces the default 'No files were renamed.'
+    heartbeat with an upload-accurate line via the empty_text key."""
+    from backend.util.notification_formatting import format_for_discord
+
+    cfg = SimpleNamespace(module_name="poster_renamerr")
+    data, ok = format_for_discord(
+        cfg,
+        {
+            "collection": [],
+            "movie": [],
+            "show": [],
+            "empty_text": "No posters were uploaded (nothing changed).",
+        },
+    )
+    assert ok
+    fields = data[1]
+    assert fields[0]["name"] == "No posters were uploaded (nothing changed)."
+
+
+def test_format_for_discord_empty_default_unchanged():
+    from backend.util.notification_formatting import format_for_discord
+
+    cfg = SimpleNamespace(module_name="poster_renamerr")
+    data, _ = format_for_discord(cfg, {"collection": [], "movie": [], "show": []})
+    assert data[1][0]["name"] == "No files were renamed."
+
+
+def test_format_for_discord_renders_artist_and_album():
+    """Music uploads must render, not silently fall through to the empty
+    heartbeat (artist/album previously weren't handled by the formatter)."""
+    from backend.util.notification_formatting import format_for_discord
+
+    cfg = SimpleNamespace(module_name="poster_renamerr")
+    data, _ = format_for_discord(
+        cfg,
+        {
+            "artist": [{"title": "Queen", "year": None, "messages": ["Uploaded to Music"]}],
+            "album": [
+                {
+                    "title": "Greatest Hits",
+                    "year": 1981,
+                    "messages": ["Uploaded to Music"],
+                }
+            ],
+        },
+    )
+    names = [f.get("name", "") for fields in data.values() for f in fields]
+    assert any("Queen" in n for n in names)
+    assert any("Greatest Hits (1981)" in n for n in names)
+    assert not any("No files were renamed" in n for n in names)

--- a/tests/test_plex_connect.py
+++ b/tests/test_plex_connect.py
@@ -200,6 +200,17 @@ def test_locate_targets_lone_titleonly_hit_keeps_yearless_candidate():
     assert targets == [yearless]
 
 
+def test_locate_targets_lone_titleonly_hit_rejects_malformed_year():
+    """A lone hit with a non-empty MALFORMED year fails closed — an
+    unverifiable candidate must not receive the poster (only genuinely
+    missing years are treated as a metadata gap)."""
+    client = _client_with_year_aware_search(
+        year_results=[], titleonly_results=[_FakeMovie("not-a-year")]
+    )
+    targets = client._locate_targets("Films", "Thanks for Sharing", year=2018)
+    assert targets == []
+
+
 def _client_with_fetchitem(item_or_exc, search_counter):
     """PlexClient whose plex.fetchItem returns an item (or raises) and whose
     section.search is counted, to prove ratingKey resolution skips searching."""

--- a/tests/test_plex_connect.py
+++ b/tests/test_plex_connect.py
@@ -176,6 +176,30 @@ def test_locate_targets_year_tolerant_fallback_rejects_off_by_two():
     assert targets == []
 
 
+def test_locate_targets_lone_titleonly_hit_rejects_wrong_year():
+    """A LONE title-only hit of a clearly different year is a different release
+    (e.g. a remake) and must NOT receive the poster — the single-candidate
+    branch is year-guarded like the multi-candidate one. Regression: a
+    'Halloween' (2018) poster landed on the 1978 item when only the 1978 film
+    was in the library."""
+    client = _client_with_year_aware_search(
+        year_results=[], titleonly_results=[_FakeMovie(1978)]
+    )
+    targets = client._locate_targets("Films", "Thanks for Sharing", year=2018)
+    assert targets == []
+
+
+def test_locate_targets_lone_titleonly_hit_keeps_yearless_candidate():
+    """A lone hit with NO year (Plex metadata gap) is kept — a missing year
+    must not reject the only candidate (mirrors _disambiguate_by_year)."""
+    yearless = _FakeMovie(None)
+    client = _client_with_year_aware_search(
+        year_results=[], titleonly_results=[yearless]
+    )
+    targets = client._locate_targets("Films", "Thanks for Sharing", year=2018)
+    assert targets == [yearless]
+
+
 def _client_with_fetchitem(item_or_exc, search_counter):
     """PlexClient whose plex.fetchItem returns an item (or raises) and whose
     section.search is counted, to prove ratingKey resolution skips searching."""

--- a/tests/test_poster_renamerr.py
+++ b/tests/test_poster_renamerr.py
@@ -1202,3 +1202,64 @@ def test_adhoc_match_runs_under_rebuild_lock(monkeypatch):
     result = m.run_poster_rename_adhoc([{"asset_type": "movie", "id": 1}])
     assert result["success"] is True
     assert observed == [False], "match_item ran without the rebuild lock held"
+
+
+# --- _build_plex_notify_output (plex-path notification payload) ---
+
+
+def test_build_plex_notify_output_lists_only_genuine_uploads():
+    """The plex-path notification is built from the uploader's payload
+    ("uploaded" = action=='updated' only) — staged/skipped/failed posters must
+    never appear, so re-flow retries can't spam every scheduled run."""
+    upload_result = {
+        "success": True,
+        "payload": {
+            "updated": 3,
+            "skipped": 40,
+            "failed": 2,
+            "uploaded": [
+                {
+                    "title": "Film",
+                    "year": "2026",
+                    "asset_type": "movie",
+                    "season_number": None,
+                    "library_name": "Movies, Movies 4K",
+                    "instance": "plex_main",
+                },
+                {
+                    "title": "Show",
+                    "year": 2020,
+                    "asset_type": "show",
+                    "season_number": 2,
+                    "library_name": "TV",
+                    "instance": "plex_main",
+                },
+                {
+                    "title": "Queen",
+                    "year": None,
+                    "asset_type": "artist",
+                    "season_number": None,
+                    "library_name": "Music",
+                    "instance": "plex_main",
+                },
+            ],
+        },
+    }
+    out = PosterRenamerr._build_plex_notify_output(upload_result)
+    assert [a["title"] for a in out["movie"]] == ["Film"]
+    assert out["movie"][0]["messages"] == ["Uploaded to Movies, Movies 4K"]
+    assert out["show"][0]["messages"] == ["Season 02 uploaded to TV"]
+    assert out["artist"][0]["title"] == "Queen"
+    assert out["collection"] == [] and out["album"] == []
+
+
+def test_build_plex_notify_output_empty_and_none_are_all_empty():
+    """Zero genuine uploads (steady state) and a missing/failed upload result
+    both produce the all-empty shape — the caller then sends the one-line
+    heartbeat instead of a poster list."""
+    empty = PosterRenamerr._build_plex_notify_output(
+        {"success": True, "payload": {"uploaded": []}}
+    )
+    assert not any(empty.values())
+    assert not any(PosterRenamerr._build_plex_notify_output(None).values())
+    assert not any(PosterRenamerr._build_plex_notify_output({}).values())


### PR DESCRIPTION
## Summary

Follow-up to a full audit of the poster_renamerr → upload-to-Plex path (`apply_method == "plex"`). The audit confirmed the two-layer skip-unchanged pipeline is sound — a steady-state scheduled run uploads nothing — but surfaced four fixes, all bounded/config-gated:

### 1. Notifications report genuine uploads only (`upload_posters.py`, `poster_renamerr.py`, `notification_formatting.py`)
The scheduled run notified from the **staged** set and discarded the uploader's outcome (`PosterUploader(...).run()` return was unused), so skipped/failed posters — including per-run re-flow retries — appeared in Discord/Notifiarr as uploads on every schedule.
- The uploader payload now carries `uploaded`: per-poster records for `action == "updated"` only (title/year/season/library/instance).
- The plex path notifies from that (`Uploaded to Movies, Movies 4K`, `Season 02 uploaded to TV`); when nothing genuinely uploaded, a one-line heartbeat replaces the poster list: `No posters were uploaded (nothing changed).` or `No posters were uploaded (N failed — check the logs).`
- Kometa path unchanged (there the rename output *is* the outcome). Mirrors the webhook path's existing outcome-gated pattern (`job_processor._handle_post_rename_actions`).
- The formatter now renders artist/album too, so music-only runs no longer misreport as "No files were renamed."

### 2. Plex border pass restricted to the manifest (`border_replacerr.py`, `poster_renamerr.py`)
The plex path ran the border pass with `process_all=True`, sweeping **all** matched rows. Layer-A-skipped rows point at prior runs' deleted staging dirs, so every poster was re-decoded/re-encoded into a recreated stale `/tmp/chub_poster_plex_*` dir that nothing cleans (RAM-backed /tmp on Unraid) — pure waste; nothing uploads from there. New `manifest_only` flag hard-restricts the plex border pass to this run's manifest, overriding **every** full-library trigger (`process_all`, holiday `reset_all`, missing manifest). Kometa keeps its full-library re-border.

### 3. Year-guard on the lone live-search candidate (`plex.py`)
The live title-only fallback accepted a lone candidate with **no year check** (only the multi-candidate branch was year-tolerant), so a poster could land on a same-title sibling of a clearly different year (a 2018 poster on the 1978 original) when the cache missed. The single-candidate branch now applies the same ±tolerance; a candidate with NO year is kept (a metadata gap must not reject the only candidate — mirrors `PlexMediaIndex._disambiguate_by_year`).

### 4. Border-excluded assets get staged unbordered (`border_replacerr.py`)
With borders enabled the border op is the sole file writer, so an `exclusion_list`/`ignore_folders` title never got a staged file — the plex uploader failed "Could not read poster file" on **every** run and the kometa destination stayed empty. Excluded assets now get a crash-safe unbordered copy staged (exclusion means *no border*, not *no poster*). The manifest branch's duplicated inline exclusion checks were consolidated into `_asset_excluded`.

### Also
- Structural `dry_run` guard on the hash-equal persist branch in `_sync_single_asset` (unreachable today, guarded anyway).
- Collection analogue of the media skip-column persistence test — `source_file_hash`/`uploaded_libraries`/`file_hash`/`file_mtime`/`original_file` must survive a collections re-sync upsert or every collection would re-upload each run (previously untested; guards the `ON CONFLICT DO UPDATE SET` column list).

## Behavior changes to note
- An excluded title now uploads/stages an **unbordered** poster instead of nothing; on kometa, an old bordered copy at the destination is refreshed to the unbordered source on the next pass.
- On the plex path, a border-settings/holiday change no longer triggers the (previously useless) full re-encode; posters already in Plex keep their old border until their source changes — pre-existing limitation, now explicit instead of hidden behind wasted CPU.

## Test plan
- `ruff check .` clean; full `pytest` green.
- New tests: notify-builder unit tests (genuine-uploads-only, empty/None shapes), formatter `empty_text` override + artist/album rendering, lone-hit year-guard (wrong-year rejected / year-less kept), `manifest_only` overrides `process_all` e2e, excluded-manifest-asset staged with exact source bytes e2e, collection skip-column persistence across re-sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plex poster processing now targets manifest-tracked assets and notification reporting lists only posters that were genuinely uploaded.
  - Excluded posters are still staged/copied (without border work) so uploads can continue smoothly.
  - Discord/Plex notifications now include Artist and Album details and use clearer “nothing changed” messaging when applicable.

- **Bug Fixes**
  - Improved Plex matching rejects single title-only hits when the release year conflicts or is malformed.
  - Dry runs no longer perform unnecessary database writes when poster bytes are unchanged.
  - Upload results now report year and season number.

- **Tests**
  - Added/expanded coverage for manifest-only behavior, staging of excluded posters, notification payload correctness, and year-matching edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->