### PR TITLE
ci: add weekly OSV dependency-audit workflow

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -1,0 +1,38 @@
+name: "Dependency Audit"
+
+# Live OSV scan of the dependencies the release actually ships. Renovate keeps
+# versions fresh but never checks advisories; this is the vulnerability gate.
+# Weekly + on any PR that changes the audited manifests. Findings land in the
+# Security tab (SARIF) and fail the run.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "43 2 * * 1"
+  pull_request:
+    paths:
+      - "requirements.txt"
+      - "frontend/package-lock.json"
+      - "deploy/docker/Dockerfile"
+      - ".github/workflows/dep-audit.yml"
+
+permissions: {}
+
+jobs:
+  osv-scan:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    permissions:
+      # Least-privilege for the reusable workflow: SARIF upload + checkout.
+      actions: read
+      contents: read
+      security-events: write
+    with:
+      # Only what ships: backend pins + frontend lockfile. refs/ holds vendored
+      # reference repos and must not be scanned; requirements-cl2k.txt is
+      # develop-only and absent on main, so it cannot be listed here.
+      scan-args: |-
+        -L
+        requirements.txt
+        -L
+        frontend/package-lock.json
+      fail-on-vuln: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ PlexAPI==4.18.2
 pluggy==1.6.0
 prettytable==3.18.0
 pydantic==2.13.4
+Pygments==2.20.0
 pytest==9.1.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2


### PR DESCRIPTION
Adds the missing vulnerability gate found during the v2.41.1 release audit: Renovate keeps versions fresh but nothing checked advisories — the pre-release CVE audit had to be done manually.

- Weekly (Mon 02:43 UTC) + `workflow_dispatch` + PR-triggered when `requirements.txt`, `frontend/package-lock.json`, the Dockerfile, or this workflow change
- `google/osv-scanner-action` reusable workflow, SHA-pinned (v2.3.8) so Renovate manages it
- Scans exactly what ships: backend pins + frontend lockfile (`refs/` vendored repos deliberately excluded; `requirements-cl2k.txt` is develop-only/unreleased so it can't be listed in a shared workflow)
- SARIF to the Security tab; `fail-on-vuln: true`
- Caller-side least-privilege `permissions` block (reusable workflows startup_fail without it on this repo's read-only default token)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated “Dependency Audit” workflow that performs OSV vulnerability scans of the dependencies shipped with the project.
  * Scans run on a weekly schedule, on demand, and when relevant dependency/lock or workflow/deployment files change.
  * The workflow is configured to fail if any vulnerabilities are detected.

* **Dependency Updates**
  * Added `Pygments` version `2.20.0` to the backend dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->